### PR TITLE
Extended conj to nil

### DIFF
--- a/pixie/vm/persistent_list.py
+++ b/pixie/vm/persistent_list.py
@@ -56,6 +56,10 @@ def _conj(self, itm):
     assert isinstance(self, PersistentList)
     return PersistentList(itm, self, self._cnt + 1, nil)
 
+@extend(_conj, nil._type)
+def _conj(_, itm):
+    return PersistentList(itm, nil, 1, nil)
+
 def count(self):
         cnt = 0
         while self is not nil:


### PR DESCRIPTION
Clojure semantics is that `(conj nil x)` -> `(x)`, which is useful when conj is given as an argument to e.g., `update-in`.
