### PR TITLE
support string return values from ffi functions

### DIFF
--- a/pixie/stdlib.lisp
+++ b/pixie/stdlib.lisp
@@ -411,6 +411,7 @@
  (def exit (ffi-fn libc "exit" [Integer] Integer))
  (def puts (ffi-fn libc "puts" [String] Integer))
  (def printf (ffi-fn libc "printf" [String] Integer))
+ (def getenv (ffi-fn libc "getenv" [String] String))
 
 (defn print [& args]
   (puts (apply str args)))

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -4,6 +4,7 @@ import pixie.vm.code as code
 from pixie.vm.code import as_var, affirm
 import pixie.vm.rt as rt
 from rpython.rtyper.lltypesystem import rffi, lltype
+from pixie.vm.primitives import nil
 from pixie.vm.numbers import Integer
 from pixie.vm.string import String
 from rpython.rlib.jit_libffi import CIF_DESCRIPTION
@@ -76,6 +77,12 @@ def get_ret_val(ptr, tp):
         pnt = rffi.cast(rffi.LONGP, ptr)
         val = pnt[0]
         return Integer(val)
+    if tp == String._type:
+        pnt = rffi.cast(rffi.CCHARPP, ptr)
+        if pnt[0] == lltype.nullptr(rffi.CCHARP.TO):
+            return nil
+        else:
+            return String(rffi.charp2str(pnt[0]))
 
     assert False
 


### PR DESCRIPTION
this works for `getenv`, but i think it doesn't ever free the values. how would one do that?

i used this snippet for testing the memory usage:

``` clojure
(loop [x 0]
  (if (eq x 1000000)
    x
    (do
      (getenv "HOME")
      (recur (inc x)))))
```

a bit more troubling, the same snippet, but with `(str "just " "an " "example")` instead of the `getenv` call also doesn't seem to free anything.
