### PR TITLE
Allow running as a shebang executable

### DIFF
--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -319,6 +319,10 @@ def load_file(filename):
         data = f.read()
         f.close()
 
+        if data.startswith("#!"):
+            newline_pos = data.find("\n")
+            if newline_pos > 0:
+                data = data[newline_pos:]
         rdr = reader.StringReader(unicode(data))
 
         with compiler.with_ns(u"user"):


### PR DESCRIPTION
E.g. the following works:

``` clojure
#!./pixie-vm

(print "Hello, World!")
```

The shebang is stripped from _all_ loaded files if it is present, but I think it should be ok. (That way you can also `require` "runnable" namespaces.
