### PR TITLE
Namespace improvements

### DIFF
--- a/pixie/stdlib.lisp
+++ b/pixie/stdlib.lisp
@@ -492,7 +492,7 @@
 (defmacro require [ns kw as-nm]
   (assert (= kw :as) "Require expects :as as the second argument")
   `(do (load-file (quote ~ns))
-       (refer (this-ns-name) (the-ns (quote ~ns)) (quote ~as-nm))))
+       (refer-ns (this-ns-name) (the-ns (quote ~ns)) (quote ~as-nm))))
 
 (defmacro ns [nm & body]
   `(do (__ns__ ~nm)
@@ -737,3 +737,27 @@
                  (if result
                    (xf acc result)
                    acc))))))
+
+(defn refer [ns-sym & filters]
+  (let [ns (or (the-ns ns-sym) (throw (str "No such namespace: " ns-sym)))
+        filters (apply hashmap filters)
+        nsmap (ns-map ns)
+        rename (or (:rename filters) {})
+        exclude (set (:exclude filters))
+        refers (if (= :all (:refer filters))
+                 (keys nsmap)
+                 (or (:refer filters) (:only filters) (keys nsmap)))]
+    (when (and refers (not (satisfies? ISeqable refers)))
+      (throw ":only/:refer must be a collection of symbols"))
+    (loop [syms (seq refers)]
+      (if (not syms)
+        nil
+        (do
+          (let [sym (first syms)]
+            (when-not (exclude sym)
+              (let [v (nsmap sym)]
+                (when-not v
+                  (throw (str sym "does not exist")))
+                (refer-symbol *ns* (or (rename sym) sym) v))))
+          (recur (next syms)))))
+    nil))

--- a/pixie/vm/code.py
+++ b/pixie/vm/code.py
@@ -452,6 +452,17 @@ class Namespace(object.Object):
 
         self._refers[as_nm] = Refer(ns, refer_all=refer_all)
 
+    def add_refer_symbol(self, sym, var):
+        assert isinstance(self, Namespace)
+
+        name = rt.name(sym)
+        prev_binding = self._registry.get(name, None)
+        if prev_binding is not None:
+            print rt.str(rt.wrap(u"Warning: "), sym, rt.wrap(u" already refers to "), prev_binding)._str
+
+        self._registry[name] = var
+        return var
+
     def include_stdlib(self):
         stdlib = _ns_registry.find_or_make(u"pixie.stdlib")
         self.add_refer(stdlib, refer_all=True)

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -384,7 +384,7 @@ def ns_map(ns):
 
     return m
 
-@as_var("refer")
+@as_var("refer-ns")
 def refer(ns, refer, alias):
     from pixie.vm.symbol import Symbol
 
@@ -395,6 +395,16 @@ def refer(ns, refer, alias):
     ns.add_refer(refer, rt.name(alias))
     return nil
 
+@as_var("refer-symbol")
+def refer_symbol(ns, sym, var):
+    from pixie.vm.symbol import Symbol
+
+    affirm(isinstance(ns, code.Namespace), u"First argument must be a namespace")
+    affirm(isinstance(sym, Symbol) and rt.namespace(sym) is None, u"Second argument must be a non-namespaced symbol")
+    affirm(isinstance(var, code.Var), u"Third argument must be a var")
+
+    ns.add_refer_symbol(sym, var)
+    return nil
 
 @as_var("extend")
 def _extend(proto_fn, tp, fn):


### PR DESCRIPTION
We can retrieve vars from namespaces using `ns-map` now and I've used that to implement a `refer` that's similar to Clojure's. The existing `refer` is now called `refer-ns`.
