### PR TITLE
Support for multimethods

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1230,11 +1230,13 @@
       `(fn* ~name ~(first (first decls)) ~@(next (first decls)))
       `(fn* ~name ~@decls))))
 
-(deftype MultiMethod [dispatch-fn methods]
+(deftype MultiMethod [dispatch-fn default-val methods]
   IFn
   (-invoke [self dispatch-arg & args]
     (let [dispatch-val (dispatch-fn dispatch-arg)
-          method (get @methods dispatch-val)
+          method (if (contains? @methods dispatch-val)
+                   (get @methods dispatch-val)
+                   (get @methods default-val))
           _ (assert method (str "no method defined for " dispatch-val))]
       (apply method dispatch-arg args))))
 
@@ -1245,8 +1247,9 @@
         [meta args] (if (map? (first args))
                       [(merge meta (first args)) (next args)]
                       [meta args])
-        dispatch-fn (first args)]
-    `(def ~name (->MultiMethod ~dispatch-fn (atom {})))))
+        dispatch-fn (first args)
+        options (apply hashmap (next args))]
+    `(def ~name (->MultiMethod ~dispatch-fn ~(get options :default :default) (atom {})))))
 
 (defmacro defmethod [name dispatch-val params & body]
   `(do


### PR DESCRIPTION
This was surprisingly easy, so perhaps I'm missing something. I have _not_ implemented hierarchies so far, and probably won't for this PR. I _am_ pretty happy that we can implement this without modifying the runtime.

Before merging I'd like to add a few tests tomorrow.

Here's what works so far:

``` clojure
(defmulti greet first)

(defmethod greet :hi [[_ name]] (print "Hi, " name "!"))
(defmethod greet :hello [[_ name]] (print "Hello, " name "."))
(defmethod greet :default [_] (print "Uh, hi, hrglmbl."))

(greet [:hi "friend"])
; Hi, friend!

(greet [:hello "friend"])
; Hello, friend.

(greet [:mystery])
; Uh, hi, hrglmbl.
```
