### PR TITLE
Add mac install instructions and dust link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are having trouble building on Mac, checkout this issue
 In particular, try this:
 
 ```
-export PKG_CONFIG_PATH='/usr/local/Cellar/libffi/3.0.13/lib/pkgconfig:/usr/local/Cellar/libffi/3.0.13/lib/pkgconfig
+PKG_CONFIG_PATH='/usr/local/Cellar/libffi/3.0.13/lib/pkgconfig' ./make-with-jit
 ```
 
 ## Running the tests


### PR DESCRIPTION
It seems like mac users are running into install problems.  Added a pointer to the common issue and workaround.

Also added a section to link to dust.
