### PR TITLE
naive shell using ffi

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -3,7 +3,7 @@
  (def libc (ffi-library pixie.platform/lib-c-name))
  (def exit (ffi-fn libc "exit" [Integer] Integer))
  (def puts (ffi-fn libc "puts" [String] Integer))
- (def shell (ffi-fn libc "system" [String] Integer))
+ (def sh (ffi-fn libc "system" [String] Integer))
  (def printf (ffi-fn libc "printf" [String] Integer))
  (def getenv (ffi-fn libc "getenv" [String] String))
 


### PR DESCRIPTION
I would like to use pixie to do some scripting.

Here is a crack at trying to implement a _shell_ function. It returns the exit code.

```
-> ./pixie-vm
Pixie 0.1 - Interactive REPL
(darwin_x86_64, clang)
:exit-repl or Ctrl-D to quit
----------------------------
user => (shell "ls")
COPYING         README.md       foo         pixie-vm        target.pyc
COPYING.LESSER      benchmarks      make-no-jit     run-interpreted     tests
Dockerfile      checkout-externals  make-with-jit       run-tests.pxi
Makefile        examples        pixie           target.py
0
user => 
```

```
user => (shell "mkdir 'foobar'")
0
```

I am definitely don't know my way around python, ffi, or libuv very well, so if there is a better way to implement this, please let me know. 
