### PR TITLE
Make iterators a bit friendlier to use

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1525,6 +1525,9 @@ For more information, see http://clojure.org/special_forms#binding-forms"}
     nil
     (cons (current i) (lazy-seq (iterator-seq (move-next! i))))))
 
+(extend -first IIterator -current)
+(extend -iterator IIterator identity)
+
 (extend -seq IIterator iterator-seq)
 (extend -seq IIterable (comp seq iterator))
 
@@ -1558,6 +1561,7 @@ For more information, see http://clojure.org/special_forms#binding-forms"}
                 (let [acc (f acc (-current k))]
                   (-move-next! k)
                   (recur acc)))))))
+
 (defn filter
   {:doc "Filter the collection for elements matching the predicate."
    :signatures [[pred] [pred coll]]


### PR DESCRIPTION
`first` now works on any IIterator, returning `-current`, and
`-iterator` is supported on IIterators as well to make the following
possible:

```
(map inc (distinct [1 2 3 1 -1 10]))
```
