### PR TITLE
Add --thread option to make-no-jit script

### DIFF
--- a/make-no-jit
+++ b/make-no-jit
@@ -1,1 +1,1 @@
-python ../externals/pypy/rpython/bin/rpython --continuation --no-shared --lldebug target.py
+python ../externals/pypy/rpython/bin/rpython --continuation --no-shared --lldebug --thread target.py


### PR DESCRIPTION
On OS X 10.9.5

 When I checkout master and execute `./make-no-jit` I get the following failed assertion:

```
[translation:ERROR] AssertionError
[translation] start debugger...
> /Users/frank/Projects/externals/pypy/rpython/memory/gctransform/framework.py(1077)gct_gc_thread_run()
-> assert self.translator.config.translation.thread
```

It seems like the translator thread config option is not enabled by default. I've included the tread option
in `./make-no-jit`.
