### PR TITLE
Refactor build script to include travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
+env:
+  - JIT_OPTS='--opt=jit' TARGET_OPTS='target.py'
+  - JIT_OPTS='' TARGET_OPTS='target.py'
+  - JIT_OPTS='--opt=jit' TARGET_OPTS='target_preload.py'
+  - JIT_OPTS='' TARGET_OPTS='target_preload.py'
+
+matrix:
+  fast_finish: true 
 
 script:
-  - make PYTHON=python build_with_jit
+  - make PYTHON=python build
   - make run_built_tests
 
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ EXTERNALS=../externals
 PYTHON ?= pypy
 PYTHONPATH=$$PYTHONPATH:$(EXTERNALS)/pypy
 
+COMMON_BUILD_OPTS?=--thread --no-shared
+JIT_OPTS?=--opt=jit
+TARGET_OPTS?=target.py
+
 help:
 	@echo "make help                   - display this message"
 	@echo "make run                    - run the compiled interpreter"
@@ -17,16 +21,19 @@ help:
 	@echo "make build_preload_no_jit   - build without jit and preload the stdlib"
 
 build_with_jit: fetch_externals
-	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython --opt=jit --thread --no-shared target.py
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) --opt=jit target.py
 
 build_no_jit: fetch_externals
-	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython --thread --no-shared target.py
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) target.py
 
 build_preload_with_jit: fetch_externals
-	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython --opt=jit --thread --no-shared target_preload.py 2>&1 >/dev/null | grep -v 'WARNING'
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) --opt=jit target_preload.py 2>&1 >/dev/null | grep -v 'WARNING'
 
 build_preload_no_jit: fetch_externals
-	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython --thread --no-shared target_preload.py
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) target_preload.py
+
+build: fetch_externals
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) $(JIT_OPTS) $(TARGET_OPTS) 2>&1 >/dev/null | grep -v 'WARNING'
 
 fetch_externals: $(EXTERNALS)/pypy
 


### PR DESCRIPTION
I believe the cause of these two build issues:

https://github.com/pixie-lang/pixie/pull/129 and https://github.com/pixie-lang/pixie/pull/131 

Were due to neither the build script nor the Travis builds building all the possible configurations (e.g. with/without JIT, with/without preload). I thought we could use Travis to build all the different versions for us.

This PR refactors out the build options into environment variables so we can use them in a Travis build matrix. Here's a screen shot of Travis building all the configs in a matrix with all the tests passing:

http://i.imgur.com/MOPR3y0.png
