### PR TITLE
Fix bug in filter, add tests

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1631,7 +1631,8 @@ For more information, see http://clojure.org/special_forms#binding-forms"}
     (let [iter (iterator coll)]
       (loop []
         (when (not (at-end? iter))
-          (yield (current iter))
+          (if (f (current iter))
+            (yield (current iter)))
           (move-next! iter)
           (recur))))))
 

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -224,6 +224,22 @@
   (t/assert= (some even? []) false)
   (t/assert= (some odd? [2]) false))
 
+(t/deftest test-filter
+  (t/assert= (vec (filter (fn [x] true) [])) [])
+  (t/assert= (vec (filter (fn [x] false) [])) [])
+  (t/assert= (vec (filter (fn [x] true) [1 2 3 4])) [1 2 3 4])
+  (t/assert= (vec (filter (fn [x] false) [1 2 3 4])) [])
+  (t/assert= (vec (filter (fn [x] true))
+                  [1 2 3 4])
+              [1 2 3 4])
+  (t/assert= (vec (filter (fn [x] false))
+                  [1 2 3 4])
+              [])
+  (t/assert= (seq (filter (fn [x] true) [])) nil)
+  (t/assert= (seq (filter (fn [x] false) [])) nil)
+  (t/assert= (seq (filter (fn [x] true) [1 2 3 4])) '(1 2 3 4))
+  (t/assert= (seq (filter (fn [x] false) [1 2 3 4])) nil))
+
 (t/deftest test-distinct
   (t/assert= (seq (distinct [1 2 3 2 1])) '(1 2 3))
   (t/assert= (vec (distinct) [1 1 2 2 3 3]) [1 2 3])


### PR DESCRIPTION
- Fix a bug that prevented `filter` from filtering when given both a predicate and a collection.
- Add unit tests for `filter`.
