### PR TITLE
Travis ignore preload fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
   - sudo apt-get install libffi-dev libedit-dev
 
 notifications:
-  irc: "chat.freenode.net#pixie-lang"
+  # irc: "chat.freenode.net#pixie-lang"


### PR DESCRIPTION
This PR fixes the .travis.yml allow_failures matrix so that it _actually_ allows build failures without failing the entire build.

Here's a screenshot of the desired build behavior:

Notice the matrix failures despite the entire build passing.
http://i.imgur.com/88Q1dpn.png
