### PR TITLE
arity check for FFI functions

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -5,7 +5,7 @@
  (def puts (ffi-fn libc "puts" [CCharP] CInt))
 
  (def sh (ffi-fn libc "system" [CCharP] CInt))
- (def printf (ffi-fn libc "printf" [CCharP] CInt))
+ (def printf (ffi-fn libc "printf" [CCharP] CInt :variadic? true))
  (def getenv (ffi-fn libc "getenv" [CCharP] CCharP))
 
  (def libedit (ffi-library (str "libedit." pixie.platform/so-ext)))

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -10,7 +10,7 @@
 
  (def libedit (ffi-library (str "libedit." pixie.platform/so-ext)))
  (def readline (ffi-fn libedit "readline" [CCharP] CCharP))
- (def rand (ffi-fn libc "rand" [CInt] CInt))
+ (def rand (ffi-fn libc "rand" [] CInt))
  (def srand (ffi-fn libc "srand" [CInt] CInt))
  (def fopen (ffi-fn libc "fopen" [CCharP CCharP] CVoidP))
  (def fread (ffi-fn libc "fread" [CVoidP CInt CInt CVoidP] CInt))

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -74,7 +74,7 @@ class ExternalLib(object.Object):
 
 class FFIFn(object.Object):
     _type = object.Type(u"pixie.stdlib.FFIFn")
-    _immutable_fields_ = ["_is_inited", "_lib", "_name", "_arg_types[*]", "_ret_type", \
+    _immutable_fields_ = ["_is_inited", "_lib", "_name", "_arg_types[*]", "_arity", "_ret_type", \
                             "_transfer_size", "_arg0_offset", "_ret_offset", "_cd"]
 
     def type(self):
@@ -85,6 +85,7 @@ class FFIFn(object.Object):
         self._name = name
         self._lib = lib
         self._arg_types = arg_types
+        self._arity = len(arg_types)
         self._ret_type = ret_type
         #self._is_inited = False
         self.thaw()
@@ -120,6 +121,10 @@ class FFIFn(object.Object):
 
     @jit.unroll_safe
     def _invoke(self, args):
+        arity = len(args)
+        if arity < self._arity:
+            runtime_error(u"Wrong number of args to fn: got " + unicode(str(arity)) +
+                u", expected at least " + unicode(str(self._arity)))
 
         exb, tokens = self.prep_exb(args)
         cd = jit.promote(self._cd)

--- a/tests/pixie/tests/test-ffi.pxi
+++ b/tests/pixie/tests/test-ffi.pxi
@@ -8,3 +8,9 @@
         b (buffer 1024)]
     (t/assert= 10 (fread b 1 10 fp))
     (t/assert= 91 (nth b 0))))
+
+(t/deftest test-arity-check
+  (try
+    (puts)
+    (t/assert false)
+    (catch ex (t/assert= (type ex) RuntimeException))))

--- a/tests/pixie/tests/test-ffi.pxi
+++ b/tests/pixie/tests/test-ffi.pxi
@@ -10,7 +10,24 @@
     (t/assert= 91 (nth b 0))))
 
 (t/deftest test-arity-check
-  (try
-    (puts)
-    (t/assert false)
-    (catch ex (t/assert= (type ex) RuntimeException))))
+  (let [sscanf-2 (ffi-fn libc "sscanf" [CCharP CCharP] CInt)
+        sscanf-* (ffi-fn libc "sscanf" [CCharP CCharP] CInt :variadic? true)]
+    (try
+      (sscanf-2 "too few arguments")
+      (t/assert false)
+      (catch ex (t/assert= (type ex) RuntimeException)))
+
+    (try
+      (sscanf-2 "too" "many" "arguments")
+      (t/assert false)
+      (catch ex (t/assert= (type ex) RuntimeException)))
+
+    (try
+      (sscanf-* "too few arguments")
+      (t/assert false)
+      (catch ex (t/assert= (type ex) RuntimeException)))
+
+    (sscanf-2 "string" "fmt")
+    (sscanf-* "string" "fmt")
+    (sscanf-* "string" "fmt" "optional arg1" "optional arg2")
+    (t/assert true)))


### PR DESCRIPTION
Calling an FFI function with too few arguments caused a segfault. So the following features were added:

- added an optional `:variadic? true` flag to `ffi-fn`
- FFI functions throw a RuntimeException if we call them with the wrong number of arguments (equality check for normal functions, greater-than-equal check for variadic functions)
