### PR TITLE
Code arity

### DIFF
--- a/pixie/vm/code.py
+++ b/pixie/vm/code.py
@@ -187,13 +187,14 @@ class NativeFn(BaseCode):
 class Code(BaseCode):
     """Interpreted code block. Contains consts and """
     _type = object.Type(u"pixie.stdlib.Code")
-    __immutable_fields__ = ["_consts[*]", "_bytecode", "_stack_size", "_meta"]
+    __immutable_fields__ = ["_arity", "_consts[*]", "_bytecode", "_stack_size", "_meta"]
 
     def type(self):
         return Code._type
 
-    def __init__(self, name, bytecode, consts, stack_size, debug_points, meta=nil):
+    def __init__(self, name, arity, bytecode, consts, stack_size, debug_points, meta=nil):
         BaseCode.__init__(self)
+        self._arity = arity
         self._bytecode = bytecode
         self._consts = consts
         self._name = name
@@ -202,7 +203,7 @@ class Code(BaseCode):
         self._meta = meta
 
     def with_meta(self, meta):
-        return Code(self._name, self._bytecode, self._consts, self._stack_size, self._debug_points, meta)
+        return Code(self._name, self._arity, self._bytecode, self._consts, self._stack_size, self._debug_points, meta=meta)
 
     def get_debug_points(self):
         return self._debug_points
@@ -217,6 +218,10 @@ class Code(BaseCode):
             ex._ex._trace.append(object.PixieCodeInfo(self._name))
             raise
 
+    @elidable_promote()
+    def get_arity(self):
+        return self._arity
+            
     @elidable_promote()
     def get_consts(self):
         return self._consts

--- a/pixie/vm/compiler.py
+++ b/pixie/vm/compiler.py
@@ -73,7 +73,7 @@ class Context(object):
                 locals[x] = Closure(locals[x], parent_ctx)
         else:
             locals = {}
-
+        self.argc = argc
         self.bytecode = []
         self.consts = []
         self.locals = [locals]
@@ -110,7 +110,7 @@ class Context(object):
         self.recur_points.pop()
 
     def to_code(self, required_args=-1):
-        return code.Code(self.name, self.bytecode, clone(self.consts), self._max_sp + 1, self.debug_points)
+        return code.Code(self.name, self.argc, self.bytecode, clone(self.consts), self._max_sp + 1, self.debug_points)
 
     def push_arg(self, idx):
         self.bytecode.append(code.ARG)
@@ -497,8 +497,7 @@ def compile_fn(form, ctx):
         ctx.sub_sp(len(arities))
 
     else:
-        compile_fn_body(name, rt.first(form), rt.next(form), ctx)
-
+        res = compile_fn_body(name, rt.first(form), rt.next(form), ctx)
     if rt.meta(name) is not nil:
         compile_meta(rt.meta(name), ctx)
 
@@ -534,7 +533,6 @@ def compile_fn_body(name, args, body, ctx):
             body = rt.next(body)
             if body is not nil:
                 new_ctx.pop()
-
     new_ctx.bytecode.append(code.RETURN)
     closed_overs = new_ctx.closed_overs
     if len(closed_overs) == 0:

--- a/pixie/vm/interpreter.py
+++ b/pixie/vm/interpreter.py
@@ -100,8 +100,9 @@ class Frame(object):
 
     def push_arg(self, idx):
         if not 0 <= idx < len(self.args):
-            runtime_error(u"Invalid argument " + unicode(str(idx)) + u" function takes "
-                          + unicode(str(len(self.args))) + u" args")
+            runtime_error(u"Invalid number of arguments " + unicode(str(idx)) 
+                          + u" for function '" + unicode(str(self.code_obj._name)) + u"'. Expected "
+                          + unicode(str(self.code_obj.get_arity())))
 
         self.push(self.args[r_uint(idx)])
 

--- a/tests/pixie/tests/test-fns.pxi
+++ b/tests/pixie/tests/test-fns.pxi
@@ -13,3 +13,45 @@
   (t/assert= (#(+ %1 %3) 3 'ignored 4) 7)
   (t/assert= (#(- %3 %1) 3 'ignored 4) 1)
   (t/assert= (#(apply + %1 %2 %&) 1 2 3 4 5) (+ 1 2 3 4 5)))
+
+;; Note these tests are for functions of type 'Code'.
+(t/deftest test-code-arity-errors
+  (let [arity-0 (fn arity-0 [])
+        arity-1 (fn arity-1 [a])
+        arity-2 (fn arity-2 [a b])]
+    (try
+      (arity-0 :foo)
+      (catch e
+        (t/assert= 
+         (ex-msg e) 
+         "Invalid number of arguments 1 for function 'arity-0'. Expected 0")))
+    (try
+      (arity-0 :foo :bar)
+      (catch e
+        (t/assert= 
+         (ex-msg e) 
+         "Invalid number of arguments 2 for function 'arity-0'. Expected 0")))
+    (try
+      (arity-1)
+      (catch e
+        (t/assert= 
+         (ex-msg e) 
+         "Invalid number of arguments 0 for function 'arity-1'. Expected 1")))
+    (try
+      (arity-1 :foo :bar)
+      (catch e
+        (t/assert= 
+         (ex-msg e) 
+         "Invalid number of arguments 2 for function 'arity-1'. Expected 1")))
+    (try
+      (arity-2)
+      (catch e
+        (t/assert= 
+         (ex-msg e) 
+         "Invalid number of arguments 0 for function 'arity-2'. Expected 2")))
+    (try
+      (arity-2 :foo)
+      (catch e
+        (t/assert= 
+         (ex-msg e) 
+         "Invalid number of arguments 1 for function 'arity-2'. Expected 2")))))


### PR DESCRIPTION
Previously, when a function of type `pixie.code.Code` was not given the correct number of args an error was thrown. The error showed the number of arguments that were pushed on to the stack - not the number the function actually requires.

This is now fixed by adding an `_arity` value to `pixie.code.Code` and making the compiler set this value.