### PR TITLE
Added python or pypy to prereqs and changed default to python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: help
 
 EXTERNALS=../externals
 
-PYTHON ?= pypy
+PYTHON ?= python
 PYTHONPATH=$$PYTHONPATH:$(EXTERNALS)/pypy
 
 COMMON_BUILD_OPTS?=--thread --no-shared --gcrootfinder=shadowstack

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Some planned and implemented features:
 
 ## Dependencies
 
+*  python or pypy to build
 *  [libffi-dev](https://sourceware.org/libffi/)
 *  [libedit-dev](http://thrysoee.dk/editline/)
 


### PR DESCRIPTION
Change the defaults to python rather than pypy so that you have to have one less thing installed to build.

Also, the externals already download pypy.