### PR TITLE
Penultimate

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -838,6 +838,13 @@ If further arguments are passed, invokes the method named by symbol, passing the
       (recur (conj res (first coll)) (next coll))
       (seq res))))
 
+(defn penultimate
+  {:doc "Returns the second to last element of the collection, or nil if none."
+   :signatures [[coll]]
+   :added "0.1"}
+  [coll]
+  (last (butlast coll) ))
+
 (defn complement
   {:doc "Given a function, return a new function which takes the same arguments
          but returns the opposite truth value"}

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -90,6 +90,18 @@
     (t/assert= (butlast l) res)
     (t/assert= (butlast r) res)))
 
+(t/deftest test-penultimate
+  (let [v [1 2 3 4 5]
+        l '(1 2 3 4 5)
+        r (range 1 6)]
+    (t/assert= (penultimate nil) nil)
+    (t/assert= (penultimate []) nil)
+    (t/assert= (penultimate (range 0 0)) nil)
+    (t/assert= (penultimate v) 4)
+    (t/assert= (penultimate l) 4)
+    (t/assert= (penultimate r) 4)
+    (t/assert= (penultimate [2]) nil)))
+
 (t/deftest test-empty?
   (t/assert= (empty? []) true)
   (t/assert= (empty? '()) true)


### PR DESCRIPTION
At the presentation of Cincy Functional Programmers, we took a tour of Pixie
and decided to add a _penultimate_ function that returns the second to last element in a collection.

Note that Clojure totally doesn't have this.
:sparkles: 
