### PR TITLE
FFI infer now uses compilation flags from rpython's system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - make run_built_tests
 
 before_install:
-  - sudo apt-get install libffi-dev libedit-dev
+  - sudo apt-get install libffi-dev libedit-dev libboost-all-dev
 
 notifications:
   irc: "chat.freenode.net#pixie-lang"

--- a/pixie/PixieChecker.hpp
+++ b/pixie/PixieChecker.hpp
@@ -15,7 +15,13 @@ namespace PixieChecker {
 template<class T>
 struct GenericChecker;
 
-
+template < typename T > std::string to_string( const T& n )
+{
+    std::ostringstream stm ;
+    stm << n ;
+    return stm.str() ;
+}
+    
 
 // Function Checker
 template <int Arity, class T>
@@ -197,7 +203,7 @@ struct GenericCheckerIsFloat<boost::true_type, T>
 {
     static std::string getType()
     {
-        return "{:type :float :size " + std::to_string(sizeof(T)) + "}";
+        return "{:type :float :size " + to_string(sizeof(T)) + "}";
     }
 };
 
@@ -228,7 +234,7 @@ struct GenericCheckerIsInt<boost::true_type, T>
 {
     static std::string getType()
     {
-        return "{:type :int :size " + std::to_string(sizeof(T)) +
+        return "{:type :int :size " + to_string(sizeof(T)) +
         " :signed? " + (boost::is_signed<T>::value ? "true" : "false") +
         "}";
     }
@@ -271,5 +277,4 @@ void DumpType()
 }
 
 }
-
 

--- a/pixie/ffi-infer.pxi
+++ b/pixie/ffi-infer.pxi
@@ -117,7 +117,7 @@ return 0;
                                (end-string)))
   (let [cmd-str (str "c++ "
                      (apply str (interpose " " pixie.platform/c-flags))
-                     " -std=gnu++11 /tmp/tmp.cpp -I"
+                     "  /tmp/tmp.cpp -I"
                      (first @load-paths)
                      (apply str " " (interpose " " (:cxx-flags *config*)))
                      " -o /tmp/a.out && /tmp/a.out")
@@ -137,7 +137,6 @@ return 0;
      (doseq [b body]
        (eval b))
      `(binding [*library* (ffi-library ~(full-lib-name (:library config)))]
-        (println "ll  " *library*)
         ~(run-infer *config* @*bodies*))))
 
 (defmacro defcfn [nm]

--- a/pixie/ffi-infer.pxi
+++ b/pixie/ffi-infer.pxi
@@ -117,7 +117,7 @@ return 0;
                                (end-string)))
   (let [cmd-str (str "c++ "
                      (apply str (interpose " " pixie.platform/c-flags))
-                     " -std=c++11 /tmp/tmp.cpp -I"
+                     " -std=gnu++11 /tmp/tmp.cpp -I"
                      (first @load-paths)
                      (apply str " " (interpose " " (:cxx-flags *config*)))
                      " -o /tmp/a.out && /tmp/a.out")

--- a/pixie/vm/libs/platform.py
+++ b/pixie/vm/libs/platform.py
@@ -1,4 +1,5 @@
 from rpython.translator.platform import platform
+from pixie.vm.persistent_list import create_from_list
 from pixie.vm.string import String
 from pixie.vm.code import as_var
 from rpython.rlib.clibffi import get_libc_name
@@ -9,3 +10,14 @@ as_var("pixie.platform", "os")(String(unicode(os.name)))
 as_var("pixie.platform", "name")(String(unicode(platform.name)))
 as_var("pixie.platform", "so-ext")(String(unicode(platform.so_ext)))
 as_var("pixie.platform", "lib-c-name")(String(unicode(get_libc_name())))
+
+c_flags = []
+for itm in platform.cflags:
+    c_flags.append(String(unicode(itm)))
+
+as_var("pixie.platform", "c-flags")(create_from_list(c_flags))
+
+link_flags = []
+for itm in platform.link_flags:
+    c_flags.append(String(unicode(itm)))
+as_var("pixie.platform", "link-flags")(create_from_list(link_flags))

--- a/tests/pixie/tests/test-ffi.pxi
+++ b/tests/pixie/tests/test-ffi.pxi
@@ -1,5 +1,6 @@
 (ns pixie.tests.test-ffi
-  (require pixie.test :as t))
+  (require pixie.test :as t)
+  (require pixie.math :as m))
 
 
 
@@ -31,3 +32,6 @@
     (sscanf-* "string" "fmt")
     (sscanf-* "string" "fmt" "optional arg1" "optional arg2")
     (t/assert true)))
+
+(t/deftest test-ffi-infer
+  (t/assert= 0.5 (m/asin (m/sin 0.5))))


### PR DESCRIPTION
Should resolve a bunch of the problems getting this to run on Linux. Also includes a simple tests to make sure that ffi-infer is run during the main testing suite. 