### PR TITLE
Fix Gilardi scenario for -e

### DIFF
--- a/target.py
+++ b/target.py
@@ -154,7 +154,7 @@ class EvalFn(NativeFn):
         with with_ns(u"user"):
             NS_VAR.deref().include_stdlib()
 
-            interpret(compile(read(StringReader(unicode_from_utf8(self._expr)), True)))
+            rt.load_reader(StringReader(unicode_from_utf8(self._expr)))
 
 
 class IsPreloadFlag(object):


### PR DESCRIPTION
This didn't work, because -e would only evaluate the first form
provided:

    px -e '(ns c (require pixie.string :as s))
           (println (s/capitalize "yay"))'

Now -e works more similarly to script files, so this works fine.