### PR TITLE
update docs for libboost

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Some planned and implemented features:
 *  python or pypy to build
 *  [libffi-dev](https://sourceware.org/libffi/)
 *  [libedit-dev](http://thrysoee.dk/editline/)
+*  [libboost-all-dev](http://www.boost.org/) (`brew install boost` for Mac)
 
 ## Building
 


### PR DESCRIPTION
The tests will fail if the dependency is missing