### PR TITLE
[Proposed] nth act like clojure's nth

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -624,6 +624,14 @@ returns true"
   [n]
   (= (rem n 2) 1))
 
+(defn nth
+  {:doc "Returns the element at the idx.  If the index is not found it will return an error.
+         However, if you specify a not-found parameter, it will substitue that instead"
+   :signatures [[coll idx] [coll idx not-found]]
+   :added "0.1"}
+  ([coll idx] (-nth coll idx))
+  ([coll idx not-found] (-nth-not-found coll idx not-found)))
+
 (defn first
   {:doc "Returns the first item in coll, if coll implements IIndexed nth will be used to retreive
          the item from the collection."

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -883,7 +883,8 @@ Stops if it finds such an element."
                                 (= idx 1) (-val self))))
 (extend -nth-not-found MapEntry (fn map-entry-nth [self idx not-found]
                                   (cond (= idx 0) (-key self)
-                                        (= idx 1) (-val self))))
+                                        (= idx 1) (-val self)
+                                        :else not-found)))
 
 (extend -reduce MapEntry indexed-reduce)
 
@@ -1626,7 +1627,7 @@ For more information, see http://clojure.org/special_forms#binding-forms"}
 (extend -nth-not-found ISeq (fn [s n not-found]
                               (if (and (pos? n) s)
                                 (recur (next s) (dec n) not-found)
-                                (first s))))
+                                (or (first s) not-found))))
 
 (defn abs
   {:doc "Returns the absolute value of x."

--- a/pixie/vm/array.py
+++ b/pixie/vm/array.py
@@ -50,6 +50,15 @@ def _nth(self, idx):
     else:
         return nil
 
+@extend(proto._nth_not_found, Array)
+def _nth_not_found(self, idx, not_found):
+    assert isinstance(self, Array)
+    ival = idx.int_val()
+    if ival < len(self._list):
+        return self._list[ival]
+    else:
+        return not_found
+
 @extend(proto._reduce, Array)
 def reduce(self, f, init):
     assert isinstance(self, Array)
@@ -212,6 +221,16 @@ def _nth(self, idx):
         return rt.wrap(ord(self._buffer[ival]))
 
     return nil
+
+@extend(proto._nth_not_found, ByteArray)
+def _nth_not_found(self, idx, not_found):
+    assert isinstance(self, ByteArray)
+    affirm(isinstance(idx, Integer), u"Index must be an integer")
+    ival = idx.r_uint_val()
+    if 0 <= ival < self._cnt:
+        return rt.wrap(ord(self._buffer[ival]))
+
+    return not_found
 
 @extend(proto._count, ByteArray)
 def _count(self):

--- a/pixie/vm/array.py
+++ b/pixie/vm/array.py
@@ -48,7 +48,7 @@ def _nth(self, idx):
     if ival < len(self._list):
         return self._list[ival]
     else:
-        return nil
+        affirm(False, u"Index out of Range")
 
 @extend(proto._nth_not_found, Array)
 def _nth_not_found(self, idx, not_found):
@@ -220,7 +220,7 @@ def _nth(self, idx):
     if 0 <= ival < self._cnt:
         return rt.wrap(ord(self._buffer[ival]))
 
-    return nil
+    return affirm(False, u"Index out of Range")
 
 @extend(proto._nth_not_found, ByteArray)
 def _nth_not_found(self, idx, not_found):

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -245,6 +245,11 @@ class Buffer(object.Object):
 def _nth(self, idx):
     return rt.wrap(ord(self.nth_char(idx.int_val())))
 
+@extend(proto._nth_not_found, Buffer)
+def _nth_not_found(self, idx, not_found):
+    return rt.wrap(ord(self.nth_char(idx.int_val())))
+
+
 @extend(proto._count, Buffer)
 def _count(self):
     return rt.wrap(intmask(self.count()))

--- a/pixie/vm/persistent_vector.py
+++ b/pixie/vm/persistent_vector.py
@@ -425,6 +425,11 @@ def _nth(self, idx):
     assert isinstance(self, PersistentVector)
     return self.nth(idx.int_val())
 
+@extend(proto._nth_not_found, PersistentVector)
+def _nth_not_found(self, idx, not_found):
+    assert isinstance(self, PersistentVector)
+    return self.nth(idx.int_val(), not_found)
+
 
 @extend(proto._val_at, PersistentVector)
 def _val_at(self, key, not_found):

--- a/pixie/vm/persistent_vector.py
+++ b/pixie/vm/persistent_vector.py
@@ -64,12 +64,15 @@ class PersistentVector(object.Object):
 
         affirm(False, u"Index out of Range")
 
-    def nth(self, i, not_found=nil):
+    def nth(self, i, not_found=None):
         if 0 <= i < self._cnt:
             node = self.array_for(r_uint(i))
             return node[i & 0x01f]
 
-        return not_found
+        if not_found is None:
+            affirm(False, u"Index out of Range")
+        else:
+            return not_found
 
     def conj(self, val):
         assert self._cnt < r_uint(0xFFFFFFFF)

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -16,7 +16,7 @@ defprotocol("pixie.stdlib", "ISeqable", ["-seq"])
 
 defprotocol("pixie.stdlib", "ICounted", ["-count"])
 
-defprotocol("pixie.stdlib", "IIndexed", ["-nth"])
+defprotocol("pixie.stdlib", "IIndexed", ["-nth", "-nth-not-found"])
 
 defprotocol("pixie.stdlib", "IPersistentCollection", ["-conj", "-disj"])
 
@@ -289,6 +289,10 @@ def conj(a, b):
 @as_var("nth")
 def nth(a, b):
     return rt._nth(a, b)
+
+@as_var("nth-not-found")
+def nth_not_found(a, b, c):
+    return rt._nth_not_found(a, b, c)
 
 
 @as_var("str")

--- a/pixie/vm/string.py
+++ b/pixie/vm/string.py
@@ -55,7 +55,7 @@ def _nth(self, idx):
     i = idx.int_val()
     if 0 <= i < len(self._str):
         return Character(ord(self._str[i]))
-    raise IndexError()
+    affirm(False, u"Index out of Range")
 
 @extend(proto._nth_not_found, String)
 def _nth_not_found(self, idx, not_found):

--- a/pixie/vm/string.py
+++ b/pixie/vm/string.py
@@ -57,6 +57,14 @@ def _nth(self, idx):
         return Character(ord(self._str[i]))
     raise IndexError()
 
+@extend(proto._nth_not_found, String)
+def _nth_not_found(self, idx, not_found):
+    assert isinstance(self, String)
+    i = idx.int_val()
+    if 0 <= i < len(self._str):
+        return Character(ord(self._str[i]))
+    return not_found
+
 @extend(proto._eq, String)
 def _eq(self, v):
     assert isinstance(self, String)

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -52,6 +52,44 @@
 
   (t/assert= (-repr [1 {:a 1} "hey"]) "[1 {:a 1} \"hey\"]"))
 
+(t/deftest test-nth
+  ;; works if the index is found
+  (t/assert= (nth [1 2 3] 1) 2)
+  (t/assert= (nth '(1 2 3) 1) 2)
+  (t/assert= (nth (make-array 3) 2) nil)
+  (t/assert= (nth (range 4) 1) 1)
+  (t/assert= (nth "hithere" 1) \i)
+
+  ;; throws error for bad index
+  (try
+    (nth [1 2 3] 99)
+    (catch ex (t/assert= (ex-msg ex) "Index out of Range")))
+  (try
+    (nth '(1 2 3) 99)
+    (catch ex (t/assert= (ex-msg ex) "Index out of Range")))
+  (try
+    (nth (make-array 3) 99)
+    (catch ex (t/assert= (ex-msg ex) "Index out of Range")))
+  (try
+    (nth (range 4) 99)
+    (catch ex (t/assert= (ex-msg ex) "Index out of Range")))
+  (try
+    (nth "hithere" 99)
+    (catch ex (t/assert= (ex-msg ex) "Index out of Range")))
+
+  ;; if not-found is specified, uses that for out of range
+  (t/assert= (nth [1 2 3] 99 :default) :default)
+  (t/assert= (nth '(1 2 3) 99 :default) :default)
+  (t/assert= (nth (make-array 3) 99 :default) :default)
+  (t/assert= (nth (range 4) 99 :default) :default)
+  (t/assert= (nth "hithere" 99 :default) :default)
+
+  (t/assert= (nth [1 2 3] 1 :default) 2)
+  (t/assert= (nth '(1 2 3) 1 :default) 2)
+  (t/assert= (nth (make-array 3) 2 :default) nil)
+  (t/assert= (nth (range 4) 1 :default) 1)
+  (t/assert= (nth "hithere" 1 :deafult) \i))
+
 (t/deftest test-first
   (t/assert= (first []) nil)
   (t/assert= (first '()) nil)


### PR DESCRIPTION
Currently in pixie - if `nth` is called with a bad index, it returns nil.  It also doesn't handle default values.
The thought is, to make it easier for people to transition Clojure code to pixie, to make `nth` behave more like Clojure version.  Then we can have another function named `index` or `ith` to have a more functionality (like handling negative indexes)

This pull request does the following for `nth`:
* throws an exception "Index of out Range" for a bad index
* does not throw an exception for a bad index if a not-found value is specified, it will return that instead.

Example:

```clojure
user => (nth [1 2 3] 1)
2

user => (nth [1 2 3] 5)
Error:  in <unknown> at 15:1
(nth [1 2 3] 5)
^
in pixie function nth

in /Users/cmeier/workspace/misc/pixie/pixie/stdlib.pxi at 632:15
  ([coll idx] (-nth coll idx))
              ^
in polymorphic function -nth dispatching on pixie.stdlib.PersistentVector

in internal function _nth

RuntimeException: Index out of Range

user => (nth [1 2 3] 5 :x)
:x
```

** Note1: this is my first time in the python's vm, so any feedback on better implementation is appreciated.
** Note2: If this is not the desired behavior of Pixie, that is totally cool, trying to implement the change was a good learning experience in itself.