### PR TITLE
Add an ith function

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -838,39 +838,6 @@ If further arguments are passed, invokes the method named by symbol, passing the
       (recur (conj res (first coll)) (next coll))
       (seq res))))
 
-(defn penultimate
-  {:doc "Returns the second to last element of the collection, or nil if none."
-   :signatures [[coll]]
-   :added "0.1"}
-  [coll]
-  (last (butlast coll) ))
-
-(defn ith
-  {:doc "Returns the ith element of the collection, negative values count from the end."
-   :signatures [[coll i]]
-   :added "0.1"}
-  [coll i]
-  (if (nil? coll)
-    nil
-    (let [len (count coll)]
-      (if (and (< i len) (>= i (- len)))
-        (ith-safe coll i)
-        (throw "Index out of bounds")
-        )
-      )
-    )
-  )
-
-(comment "No bounds checking on this one")
-(defn ith-safe
-  {:doc "Returns the ith element of the collection, negative values count from the end."
-   :signatures [[coll i]]
-   :added "0.1"}
-  [coll i]
-  (if (neg? i)
-    (let [len (count coll)] (nth coll (+ i len)))
-    (nth coll i)))
-
 (defn complement
   {:doc "Given a function, return a new function which takes the same arguments
          but returns the opposite truth value"}
@@ -1463,6 +1430,20 @@ The new value is thus `(apply f current-value-of-atom args)`."
     (if (and xs (pos? n))
       (recur (dec n) (next xs))
       xs)))
+
+(defn ith
+  {:doc "Returns the ith element of the collection, negative values count from the end.
+         If an index is out of bounds, will throw an Index out of bounds exception"
+   :signatures [[coll i]]
+   :added "0.1"}
+  [coll i]
+  (if coll
+    (let [len (count coll)
+          idx (if (neg? i) (+ i len) i)
+          in-bounds? (and (< idx len) (>= idx 0))]
+      (if in-bounds?
+        (nth coll idx)
+        (throw "Index out of bounds")))))
 
 (defn take
   {:doc "Takes n elements from the collection, or fewer, if not enough."

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -845,6 +845,32 @@ If further arguments are passed, invokes the method named by symbol, passing the
   [coll]
   (last (butlast coll) ))
 
+(defn ith
+  {:doc "Returns the ith element of the collection, negative values count from the end."
+   :signatures [[coll i]]
+   :added "0.1"}
+  [coll i]
+  (if (nil? coll)
+    nil
+    (let [len (count coll)]
+      (if (and (< i len) (>= i (- len)))
+        (ith-safe coll i)
+        (throw "Index out of bounds")
+        )
+      )
+    )
+  )
+
+(comment "No bounds checking on this one")
+(defn ith-safe
+  {:doc "Returns the ith element of the collection, negative values count from the end."
+   :signatures [[coll i]]
+   :added "0.1"}
+  [coll i]
+  (if (neg? i)
+    (let [len (count coll)] (nth coll (+ i len)))
+    (nth coll i)))
+
 (defn complement
   {:doc "Given a function, return a new function which takes the same arguments
          but returns the opposite truth value"}

--- a/tests/pixie/tests/test-ith.pxi
+++ b/tests/pixie/tests/test-ith.pxi
@@ -1,0 +1,108 @@
+(ns pixie.tests.test-ith
+  (require pixie.test :as t))
+
+(t/deftest test-ith
+  (let [v [1 2 3 4 5]
+        l '(1 2 3 4 5)
+        r (range 1 6)]
+    (t/assert= (ith [1 2 3 4 5] 0) 1)
+    (t/assert= (ith v 0) 1)
+    (t/assert= (ith v 0) (nth v 0))
+    ))
+
+(t/deftest test-ith-nil
+  (t/assert= (ith nil 0) nil)
+  (t/assert= (ith nil 1) nil)
+  (t/assert= (ith nil -1) nil)
+  )
+(comment
+(t/deftest test-ith-empty-always-oob
+  (t/assert= "Index out of bounds" (try (ith [] 0)           (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith [] 1)           (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith [] -1)          (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith '() 0)          (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith '() 1)          (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith '() -1)         (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith (range 0 0) 0)  (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith (range 0 0) 1)  (catch e (ex-msg e))))
+  (t/assert= "Index out of bounds" (try (ith (range 0 0) -1) (catch e (ex-msg e))))
+  )
+
+(t/deftest test-ith-out-of-bounds
+  (let [v [1 2 3 4 5]
+        l '(1 2 3 4 5)
+        r (range 1 6)]
+    (comment ">= 5 s/b oob")
+    (t/assert= "Index out of bounds" (try (ith v  5) (catch e (ex-msg e))))
+    (t/assert= "Index out of bounds" (try (ith l  5) (catch e (ex-msg e))))
+    (t/assert= "Index out of bounds" (try (ith r  5) (catch e (ex-msg e))))
+    (comment "< -5 s/b oob")
+    (t/assert= "Index out of bounds" (try (ith v -6) (catch e (ex-msg e))))
+    (t/assert= "Index out of bounds" (try (ith l -6) (catch e (ex-msg e))))
+    (t/assert= "Index out of bounds" (try (ith r -6) (catch e (ex-msg e))))
+    )
+  )
+)
+(t/deftest test-ith-explicit
+  (let [v [1 2 3 4 5]
+        l '(1 2 3 4 5)
+        r (range 1 6)]
+
+    (t/assert= (ith v 1) (nth v 1))
+    (t/assert= (ith l 1) (nth l 1))
+    (t/assert= (ith r 1) (nth r 1))
+
+    (t/assert= (ith r 0) (nth r 0))
+    (t/assert= (ith l 0) (nth l 0))
+    (t/assert= (ith v 0) (nth v 0))
+
+    (t/assert= (ith v 2) (nth v 2))
+    (t/assert= (ith l 2) (nth l 2))
+    (t/assert= (ith r 2) (nth r 2))
+
+    (t/assert= (ith v 3) (nth v 3))
+    (t/assert= (ith l 3) (nth l 3))
+    (t/assert= (ith r 3) (nth r 3))
+
+    (t/assert= (ith v 4) (nth v 4))
+    (t/assert= (ith l 4) (nth l 4))
+    (t/assert= (ith r 4) (nth r 4))
+
+    (t/assert= (ith v -5) (nth v 0))
+    (t/assert= (ith l -5) (nth l 0))
+    (t/assert= (ith r -5) (nth r 0))
+
+    (t/assert= (ith v -4) (nth v 1))
+    (t/assert= (ith l -4) (nth l 1))
+    (t/assert= (ith r -4) (nth r 1))
+
+    (t/assert= (ith v -3) (nth v 2))
+    (t/assert= (ith l -3) (nth l 2))
+    (t/assert= (ith r -3) (nth r 2))
+
+    (t/assert= (ith v -2) (nth v 3))
+    (t/assert= (ith l -2) (nth l 3))
+    (t/assert= (ith r -2) (nth r 3))
+
+    (t/assert= (ith v -1) (nth v 4))
+    (t/assert= (ith l -1) (nth l 4))
+    (t/assert= (ith r -1) (nth r 4))
+
+    ))
+
+(t/deftest test-ith-doseq
+  (let [v [1 2 3 4 5]
+        l '(1 2 3 4 5)
+        r (range 1 6)]
+    (doseq [i (range 0 5)]
+      (t/assert= (ith v i) (nth v i))
+      (t/assert= (ith l i) (nth l i))
+      (t/assert= (ith r i) (nth r i))
+      )
+    (doseq [i (range -5 0)]
+      (t/assert= (ith v i) (nth v (+ 5 i)))
+      (t/assert= (ith l i) (nth l (+ 5 i)))
+      (t/assert= (ith r i) (nth r (+ 5 i)))
+      )
+    ))
+

--- a/tests/pixie/tests/test-ith.pxi
+++ b/tests/pixie/tests/test-ith.pxi
@@ -7,15 +7,13 @@
         r (range 1 6)]
     (t/assert= (ith [1 2 3 4 5] 0) 1)
     (t/assert= (ith v 0) 1)
-    (t/assert= (ith v 0) (nth v 0))
-    ))
+    (t/assert= (ith v 0) (nth v 0))))
 
 (t/deftest test-ith-nil
   (t/assert= (ith nil 0) nil)
   (t/assert= (ith nil 1) nil)
-  (t/assert= (ith nil -1) nil)
-  )
-(comment
+  (t/assert= (ith nil -1) nil))
+
 (t/deftest test-ith-empty-always-oob
   (t/assert= "Index out of bounds" (try (ith [] 0)           (catch e (ex-msg e))))
   (t/assert= "Index out of bounds" (try (ith [] 1)           (catch e (ex-msg e))))
@@ -25,70 +23,18 @@
   (t/assert= "Index out of bounds" (try (ith '() -1)         (catch e (ex-msg e))))
   (t/assert= "Index out of bounds" (try (ith (range 0 0) 0)  (catch e (ex-msg e))))
   (t/assert= "Index out of bounds" (try (ith (range 0 0) 1)  (catch e (ex-msg e))))
-  (t/assert= "Index out of bounds" (try (ith (range 0 0) -1) (catch e (ex-msg e))))
-  )
+  (t/assert= "Index out of bounds" (try (ith (range 0 0) -1) (catch e (ex-msg e)))))
 
 (t/deftest test-ith-out-of-bounds
   (let [v [1 2 3 4 5]
         l '(1 2 3 4 5)
         r (range 1 6)]
-    (comment ">= 5 s/b oob")
     (t/assert= "Index out of bounds" (try (ith v  5) (catch e (ex-msg e))))
     (t/assert= "Index out of bounds" (try (ith l  5) (catch e (ex-msg e))))
     (t/assert= "Index out of bounds" (try (ith r  5) (catch e (ex-msg e))))
-    (comment "< -5 s/b oob")
     (t/assert= "Index out of bounds" (try (ith v -6) (catch e (ex-msg e))))
     (t/assert= "Index out of bounds" (try (ith l -6) (catch e (ex-msg e))))
-    (t/assert= "Index out of bounds" (try (ith r -6) (catch e (ex-msg e))))
-    )
-  )
-)
-(t/deftest test-ith-explicit
-  (let [v [1 2 3 4 5]
-        l '(1 2 3 4 5)
-        r (range 1 6)]
-
-    (t/assert= (ith v 1) (nth v 1))
-    (t/assert= (ith l 1) (nth l 1))
-    (t/assert= (ith r 1) (nth r 1))
-
-    (t/assert= (ith r 0) (nth r 0))
-    (t/assert= (ith l 0) (nth l 0))
-    (t/assert= (ith v 0) (nth v 0))
-
-    (t/assert= (ith v 2) (nth v 2))
-    (t/assert= (ith l 2) (nth l 2))
-    (t/assert= (ith r 2) (nth r 2))
-
-    (t/assert= (ith v 3) (nth v 3))
-    (t/assert= (ith l 3) (nth l 3))
-    (t/assert= (ith r 3) (nth r 3))
-
-    (t/assert= (ith v 4) (nth v 4))
-    (t/assert= (ith l 4) (nth l 4))
-    (t/assert= (ith r 4) (nth r 4))
-
-    (t/assert= (ith v -5) (nth v 0))
-    (t/assert= (ith l -5) (nth l 0))
-    (t/assert= (ith r -5) (nth r 0))
-
-    (t/assert= (ith v -4) (nth v 1))
-    (t/assert= (ith l -4) (nth l 1))
-    (t/assert= (ith r -4) (nth r 1))
-
-    (t/assert= (ith v -3) (nth v 2))
-    (t/assert= (ith l -3) (nth l 2))
-    (t/assert= (ith r -3) (nth r 2))
-
-    (t/assert= (ith v -2) (nth v 3))
-    (t/assert= (ith l -2) (nth l 3))
-    (t/assert= (ith r -2) (nth r 3))
-
-    (t/assert= (ith v -1) (nth v 4))
-    (t/assert= (ith l -1) (nth l 4))
-    (t/assert= (ith r -1) (nth r 4))
-
-    ))
+    (t/assert= "Index out of bounds" (try (ith r -6) (catch e (ex-msg e))))))
 
 (t/deftest test-ith-doseq
   (let [v [1 2 3 4 5]
@@ -97,12 +43,9 @@
     (doseq [i (range 0 5)]
       (t/assert= (ith v i) (nth v i))
       (t/assert= (ith l i) (nth l i))
-      (t/assert= (ith r i) (nth r i))
-      )
+      (t/assert= (ith r i) (nth r i)))
     (doseq [i (range -5 0)]
       (t/assert= (ith v i) (nth v (+ 5 i)))
       (t/assert= (ith l i) (nth l (+ 5 i)))
-      (t/assert= (ith r i) (nth r (+ 5 i)))
-      )
-    ))
+      (t/assert= (ith r i) (nth r (+ 5 i))))))
 

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -90,18 +90,6 @@
     (t/assert= (butlast l) res)
     (t/assert= (butlast r) res)))
 
-(t/deftest test-penultimate
-  (let [v [1 2 3 4 5]
-        l '(1 2 3 4 5)
-        r (range 1 6)]
-    (t/assert= (penultimate nil) nil)
-    (t/assert= (penultimate []) nil)
-    (t/assert= (penultimate (range 0 0)) nil)
-    (t/assert= (penultimate v) 4)
-    (t/assert= (penultimate l) 4)
-    (t/assert= (penultimate r) 4)
-    (t/assert= (penultimate [2]) nil)))
-
 (t/deftest test-empty?
   (t/assert= (empty? []) true)
   (t/assert= (empty? '()) true)


### PR DESCRIPTION
This adds a more feature rich `ith` function that handles negative indexes.
It will throw an index out of bounds if the idx is bad.

It also removes `penultimate`.

It addresses this issue https://github.com/pixie-lang/pixie/issues/179

Also, if https://github.com/pixie-lang/pixie/pull/186 is merged, we should be able to take the bounds checking out of `ith`.