### PR TITLE
implement pixie.string/blank?

### DIFF
--- a/pixie/fs.pxi
+++ b/pixie/fs.pxi
@@ -106,7 +106,7 @@
     (last (string/split (abs this) ".")))
 
   (extension? [this ext]
-    (string/ends-with (abs this) ext))
+    (string/ends-with? (abs this) ext))
 
   IObject
   (-hash [this]

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1850,7 +1850,7 @@ Supported filters:
     :only   same as refer
 
 user => (refer 'pixie.string :refer :all)
-user => (refer 'pixie.string :only '(index-of starts-with ends-with))
+user => (refer 'pixie.string :only '(index-of starts-with? ends-with?))
 user => (refer 'pixie.string :rename '{index-of find})
 user => (refer 'pixie.string :exclude '(substring))"
    :added "0.1"}

--- a/pixie/string.pxi
+++ b/pixie/string.pxi
@@ -6,8 +6,8 @@
 (def index-of si/index-of)
 (def split si/split)
 
-(def ends-with si/ends-with)
-(def starts-with si/starts-with)
+(def ends-with? si/ends-with)
+(def starts-with? si/starts-with)
 
 (def trim si/trim)
 (def triml si/triml)

--- a/pixie/string.pxi
+++ b/pixie/string.pxi
@@ -49,3 +49,17 @@
         (nil? s) res
         (nil? (next s)) (str res (first s))
         :else (recur (next s) (str res (first s) seperator))))))
+
+(defn blank?
+  "True if s is nil, empty, or contains only whitespace."
+  [s]
+  (if s
+    (let [white #{\space \newline \tab \backspace \formfeed \return}
+          length (count s)]
+      (loop [index 0]
+        (if (= length index)
+          true
+          (if (white (nth s index))
+            (recur (inc index))
+            false))))
+    true))

--- a/pixie/test.pxi
+++ b/pixie/test.pxi
@@ -49,7 +49,7 @@
         pxi-files (->> dirs
                        (mapcat fs/walk-files)
                        (filter #(fs/extension? % "pxi"))
-                       (filter #(s/starts-with (fs/basename %) "test-"))
+                       (filter #(s/starts-with? (fs/basename %) "test-"))
                        (distinct))]
     (foreach [file pxi-files]
              (println "Loading " file)

--- a/tests/pixie/tests/test-strings.pxi
+++ b/tests/pixie/tests/test-strings.pxi
@@ -2,25 +2,25 @@
   (require pixie.test :as t)
   (require pixie.string :as s))
 
-(t/deftest test-starts-with
+(t/deftest test-starts-with?
   (let [s "heyhohuh"]
-    (t/assert= (s/starts-with s "") true)
-    (t/assert= (s/starts-with s "hey") true)
-    (t/assert= (s/starts-with s "heyho") true)
-    (t/assert= (s/starts-with s s) true)
+    (t/assert= (s/starts-with? s "") true)
+    (t/assert= (s/starts-with? s "hey") true)
+    (t/assert= (s/starts-with? s "heyho") true)
+    (t/assert= (s/starts-with? s s) true)
 
-    (t/assert= (s/starts-with s "ho") false)
-    (t/assert= (s/starts-with s "foo") false)))
+    (t/assert= (s/starts-with? s "ho") false)
+    (t/assert= (s/starts-with? s "foo") false)))
 
-(t/deftest test-ends-with
+(t/deftest test-ends-with?
   (let [s "heyhohuh"]
-    (t/assert= (s/ends-with s "") true)
-    (t/assert= (s/ends-with s "huh") true)
-    (t/assert= (s/ends-with s "hohuh") true)
-    (t/assert= (s/ends-with s s) true)
+    (t/assert= (s/ends-with? s "") true)
+    (t/assert= (s/ends-with? s "huh") true)
+    (t/assert= (s/ends-with? s "hohuh") true)
+    (t/assert= (s/ends-with? s s) true)
 
-    (t/assert= (s/ends-with s "hey") false)
-    (t/assert= (s/ends-with s "foo") false)))
+    (t/assert= (s/ends-with? s "hey") false)
+    (t/assert= (s/ends-with? s "foo") false)))
 
 (t/deftest test-split
   (let [s "hey,ho,huh"]

--- a/tests/pixie/tests/test-strings.pxi
+++ b/tests/pixie/tests/test-strings.pxi
@@ -134,3 +134,10 @@
 
 (t/deftest test-unicode
   (t/assert= "hâllo" "hâllo"))
+
+(t/deftest test-blank?
+  (t/assert= (s/blank? nil) true)
+  (t/assert= (s/blank? "") true)
+  (t/assert= (s/blank? " ") true)
+  (t/assert= (s/blank? " \t \n  \r ") true)
+  (t/assert= (s/blank? "  foo  ") false))


### PR DESCRIPTION
This adds an implementation of [clojure.string/blank?](https://clojuredocs.org/clojure.string/blank_q). I have no python experience so let me know if the code is not up to par.

I noticed `pixie.stdlib/empty?` is using a question mark while `pixie.string/ends-with` and `pixie.string/starts-with` are not. Is there a desired naming convention for boolean functions in pixie?