### PR TITLE
Exception printing and querying

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2114,7 +2114,7 @@ Expands to calls to `extend-type`."
    :signatures [[] [e]]
    :added "0.1"}
   ([] (pst *e))
-  ([e] (when e (ex-pr e))))
+  ([e] (when e (print (str e)))))
 
 (defn trace
   {:doc "Returns a seq of the trace of a Runtime Exception or the last Runtime Exception in *e"

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2114,7 +2114,7 @@ Expands to calls to `extend-type`."
    :signatures [[] [e]]
    :added "0.1"}
   ([] (pst *e))
-  ([e] (when *e (ex-pr *e))))
+  ([e] (when e (ex-pr e))))
 
 (defn trace
   {:doc "Returns a seq of the trace of a Runtime Exception or the last Runtime Exception in *e"

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2100,7 +2100,6 @@ Expands to calls to `extend-type`."
   ([sb] (str sb))
   ([sb item] (conj! sb item)))
 
-
 (defmacro using [bindings & body]
   (let [pairs (partition 2 bindings)
         names (map first pairs)]
@@ -2110,3 +2109,16 @@ Expands to calls to `extend-type`."
                 `(-dispose! ~nm))
               names)
        result#)))
+(defn pst
+  {:doc "Prints the trace of a Runtime Exception if given, or the last Runtime Exception in *e"
+   :signatures [[] [e]]
+   :added "0.1"}
+  ([] (pst *e))
+  ([e] (when *e (ex-pr *e))))
+
+(defn trace
+  {:doc "Returns a seq of the trace of a Runtime Exception or the last Runtime Exception in *e"
+   :signatures [[] [e]]
+   :added "0.1"}
+  ([] (trace *e))
+  ([e] (seq e)))

--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -206,9 +206,11 @@ class PolymorphicCodeInfo(ErrorInfo):
         return u"in polymorphic function " + self._name + u" dispatching on " + tp._name + u"\n"
 
     def trace_map(self):
+        tp = self._tp
+        assert isinstance(tp, Type)
         tm = {u"type" : u"polymorphic"}
         tm[u"name"] = self._name
-        tm[u"tp"] = self._tp
+        tm[u"tp"] = tp._name
         return tm
 
 class PixieCodeInfo(ErrorInfo):

--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -122,7 +122,6 @@ class RuntimeException(Object):
 
         s.extend([u"RuntimeException: " + rt.name(rt.str(self._data)) + u"\n"])
 
-
         return u"".join(s)
 
 class WrappedException(Exception):
@@ -176,12 +175,25 @@ class InterpreterCodeInfo(ErrorInfo):
     def interpreter_code_info_state(self):
         return self._line, self._line_number, self._column_number, self._file
 
+    def trace_map(self):
+        tm = {u"type" : u"interpreter"}
+        tm[u"line"] = self._line.__repr__()
+        tm[u"line_number"] = unicode(str(self._line_number))
+        tm[u"column_number"] = unicode(str(self._column_number))
+        tm[u"file"] = self._file
+        return tm
+
 class NativeCodeInfo(ErrorInfo):
     def __init__(self, name):
         self._name = name
 
     def __repr__(self):
         return u"in internal function " + self._name + u"\n"
+
+    def trace_map(self):
+        tm = {u"type" : u"native"}
+        tm[u"name"] = self._name
+        return tm
 
 class PolymorphicCodeInfo(ErrorInfo):
     def __init__(self, name, tp):
@@ -193,7 +205,11 @@ class PolymorphicCodeInfo(ErrorInfo):
         assert isinstance(tp, Type)
         return u"in polymorphic function " + self._name + u" dispatching on " + tp._name + u"\n"
 
-
+    def trace_map(self):
+        tm = {u"type" : u"polymorphic"}
+        tm[u"name"] = self._name
+        tm[u"tp"] = self._tp
+        return tm
 
 class PixieCodeInfo(ErrorInfo):
     def __init__(self, name):
@@ -201,3 +217,8 @@ class PixieCodeInfo(ErrorInfo):
 
     def __repr__(self):
         return u"in pixie function " + self._name + u"\n"
+
+    def trace_map(self):
+        tm = {u"type" : u"pixie"}
+        tm[u"name"] = self._name
+        return tm

--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -176,11 +176,15 @@ class InterpreterCodeInfo(ErrorInfo):
         return self._line, self._line_number, self._column_number, self._file
 
     def trace_map(self):
-        tm = {u"type" : u"interpreter"}
-        tm[u"line"] = self._line.__repr__()
-        tm[u"line_number"] = unicode(str(self._line_number))
-        tm[u"column_number"] = unicode(str(self._column_number))
-        tm[u"file"] = self._file
+        from pixie.vm.string import String
+        from pixie.vm.numbers import Integer
+        from pixie.vm.keyword import keyword
+
+        tm = {keyword(u"type") : keyword(u"interpreter")}
+        tm[keyword(u"line")] = String(self._line.__repr__())
+        tm[keyword(u"line-number")] = Integer(self._line_number)
+        tm[keyword(u"column-number")] = Integer(self._column_number)
+        tm[keyword(u"file")] = String(self._file)
         return tm
 
 class NativeCodeInfo(ErrorInfo):
@@ -191,8 +195,12 @@ class NativeCodeInfo(ErrorInfo):
         return u"in internal function " + self._name + u"\n"
 
     def trace_map(self):
-        tm = {u"type" : u"native"}
-        tm[u"name"] = self._name
+        from pixie.vm.string import String
+        from pixie.vm.numbers import Integer
+        from pixie.vm.keyword import keyword
+
+        tm = {keyword(u"type") : keyword(u"native")}
+        tm[keyword(u"name")] = String(self._name)
         return tm
 
 class PolymorphicCodeInfo(ErrorInfo):
@@ -206,11 +214,15 @@ class PolymorphicCodeInfo(ErrorInfo):
         return u"in polymorphic function " + self._name + u" dispatching on " + tp._name + u"\n"
 
     def trace_map(self):
+        from pixie.vm.string import String
+        from pixie.vm.numbers import Integer
+        from pixie.vm.keyword import keyword
+
         tp = self._tp
         assert isinstance(tp, Type)
-        tm = {u"type" : u"polymorphic"}
-        tm[u"name"] = self._name
-        tm[u"tp"] = tp._name
+        tm = {keyword(u"type") : keyword(u"polymorphic")}
+        tm[keyword(u"name")] = String(self._name)
+        tm[keyword(u"tp")] = String(tp._name)
         return tm
 
 class PixieCodeInfo(ErrorInfo):
@@ -221,6 +233,10 @@ class PixieCodeInfo(ErrorInfo):
         return u"in pixie function " + self._name + u"\n"
 
     def trace_map(self):
-        tm = {u"type" : u"pixie"}
-        tm[u"name"] = self._name
+        from pixie.vm.string import String
+        from pixie.vm.numbers import Integer
+        from pixie.vm.keyword import keyword
+
+        tm = {keyword(u"type") : keyword(u"pixie")}
+        tm[keyword(u"name")] = String(self._name)
         return tm

--- a/pixie/vm/rt.py
+++ b/pixie/vm/rt.py
@@ -143,7 +143,7 @@ def init():
     # stacklet.with_stacklets(run_load_stdlib)
 
     init_fns = [u"reduce", u"get", u"reset!", u"assoc", u"key", u"val", u"keys", u"vals", u"vec", u"load-file", u"compile-file",
-                u"load-ns"]
+                u"load-ns", u"hashmap"]
     for x in init_fns:
         globals()[py_str(code.munge(x))] = unwrap(code.intern_var(u"pixie.stdlib", x))
 

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -781,15 +781,15 @@ def _seq(self):
     from pixie.vm.keyword import keyword
     assert isinstance(self, RuntimeException)
     trace = vector.EMPTY
-    trace_element = hmap.EMPTY
-    trace_element = rt.assoc(trace_element, keyword(u"type"), rt.wrap(u"runtime"))
+    trace_element = rt.hashmap(keyword(u"type"), keyword(u"runtime"))
     trace_element = rt.assoc(trace_element, keyword(u"data"), rt.wrap(self._data))
     trace = rt.conj(trace, trace_element)
     for x in self._trace:
-        trace_element = hmap.EMPTY
         tmap = x.trace_map()
+        trace_element = hmap.EMPTY
         for key in tmap:
-            trace_element = rt.assoc(trace_element, keyword(key), rt.wrap(tmap[key]))
+            val = tmap[key]
+            trace_element = rt.assoc(trace_element, key, val)
 
         trace = rt.conj(trace, trace_element)
 
@@ -799,9 +799,3 @@ def _seq(self):
 def ex_msg(e):
     assert isinstance(e, RuntimeException)
     return e._data
-
-@as_var("ex-pr")
-def ex_pr(e):
-    assert isinstance(e, RuntimeException)
-    print e.__repr__()
-    return nil

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -782,7 +782,7 @@ def _seq(self):
     assert isinstance(self, RuntimeException)
     trace = vector.EMPTY
     trace_element = hmap.EMPTY
-    trace_element = rt.assoc(trace_element, keyword(u"type"), u"runtime")
+    trace_element = rt.assoc(trace_element, keyword(u"type"), rt.wrap(u"runtime"))
     trace_element = rt.assoc(trace_element, keyword(u"data"), rt.wrap(self._data))
     trace = rt.conj(trace, trace_element)
     for x in self._trace:

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -782,7 +782,7 @@ def _seq(self):
     assert isinstance(self, RuntimeException)
     trace = vector.EMPTY
     trace_element = hmap.EMPTY
-    trace_element = rt.assoc(trace_element, keyword(u"type"), keyword(u"runtime"))
+    trace_element = rt.assoc(trace_element, keyword(u"type"), u"runtime")
     trace_element = rt.assoc(trace_element, keyword(u"data"), rt.wrap(self._data))
     trace = rt.conj(trace, trace_element)
     for x in self._trace:

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -774,8 +774,23 @@ def _str(self):
     assert isinstance(self, RuntimeException)
     return rt.wrap(self.__repr__())
 
+@extend(_seq, RuntimeException)
+def _seq(self):
+    import pixie.vm.persistent_vector as vector
+    assert isinstance(self, RuntimeException)
+    trace = vector.EMPTY
+    trace = rt.conj(trace, self._data)
+    for x in self._trace:
+        trace = rt.conj(trace, rt.wrap(x.__repr__()))
+    return rt._seq(trace)
+
 @as_var("ex-msg")
 def ex_msg(e):
     assert isinstance(e, RuntimeException)
     return e._data
 
+@as_var("ex-pr")
+def ex_pr(e):
+    assert isinstance(e, RuntimeException)
+    print e.__repr__()
+    return nil

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -777,11 +777,22 @@ def _str(self):
 @extend(_seq, RuntimeException)
 def _seq(self):
     import pixie.vm.persistent_vector as vector
+    import pixie.vm.persistent_hash_map as hmap
+    from pixie.vm.keyword import keyword
     assert isinstance(self, RuntimeException)
     trace = vector.EMPTY
-    trace = rt.conj(trace, self._data)
+    trace_element = hmap.EMPTY
+    trace_element = rt.assoc(trace_element, keyword(u"type"), keyword(u"runtime"))
+    trace_element = rt.assoc(trace_element, keyword(u"data"), rt.wrap(self._data))
+    trace = rt.conj(trace, trace_element)
     for x in self._trace:
-        trace = rt.conj(trace, rt.wrap(x.__repr__()))
+        trace_element = hmap.EMPTY
+        tmap = x.trace_map()
+        for key in tmap:
+            trace_element = rt.assoc(trace_element, keyword(key), rt.wrap(tmap[key]))
+
+        trace = rt.conj(trace, trace_element)
+
     return rt._seq(trace)
 
 @as_var("ex-msg")

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -383,5 +383,5 @@
   (try
     (/ 0 0)
     (catch e
-        (t/assert= (first (trace e)) {:data "Divide by zero", :type :runtime})
+        (t/assert= (first (trace e)) {:data "Divide by zero", :type "runtime"})
         (t/assert= (second (trace e)) {:type "native", :name "_div"} ))))

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -377,3 +377,11 @@
   (t/assert= (transduce (drop-while even?) conj [2 4 6 7 8]) [7 8])
   (t/assert= (transduce (drop-while even?) conj [0 2] [1 4 6]) [0 2 1 4 6])
   (t/assert= (transduce (drop-while even?) conj [0 2] [2 4 6 7 8]) [0 2 7 8]))
+
+
+(t/deftest test-trace
+  (try
+    (/ 0 0)
+    (catch e
+        (t/assert= (first (trace e)) "Divide by zero")
+        (t/assert= (second (trace e)) "in internal function _div\n"))))

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -383,5 +383,5 @@
   (try
     (/ 0 0)
     (catch e
-        (t/assert= (first (trace e)) "Divide by zero")
-        (t/assert= (second (trace e)) "in internal function _div\n"))))
+        (t/assert= (first (trace e)) {:data "Divide by zero", :type :runtime})
+        (t/assert= (second (trace e)) {:type "native", :name "_div"} ))))

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -383,5 +383,5 @@
   (try
     (/ 0 0)
     (catch e
-        (t/assert= (first (trace e)) {:data "Divide by zero", :type "runtime"})
-        (t/assert= (second (trace e)) {:type "native", :name "_div"} ))))
+        (t/assert= (first (trace e)) {:type :runtime :data "Divide by zero"})
+        (t/assert= (second (trace e)) {:type :native :name "_div"} ))))


### PR DESCRIPTION
Some basic functions for dealing with exceptions.

This adds a way to print and turn stack traces into seqs.

It adds two functions `pst` and `trace`

`pst` works on either an exception or if no arg is given the last exception thrown as `*e`.  It will simply print the stack trace.

```clojure
user => (/ 0 0)

; orig stack trace omitted

user => (pst)
in <unknown> at 1:1
(/ 0 0)
^
in pixie function 

in /Users/cmeier/workspace/misc/pixie/pixie/stdlib.pxi at 511:10
  ([x y] (-div x y))
         ^
in internal function _div

RuntimeException: Divide by zero

nil

user => (pst *e)
in <unknown> at 1:1
(/ 0 0)
^
in pixie function 

in /Users/cmeier/workspace/misc/pixie/pixie/stdlib.pxi at 511:10
  ([x y] (-div x y))
         ^
in internal function _div

RuntimeException: Divide by zero

nil
```

`trace` also works on either an exception or if none is given, the last bound to `*e`.  It turns the trace into a seq, which someone can do further processing and inspection on.

```clojure

user => (trace)
("Divide by zero" "in internal function _div\n" "in /Users/cmeier/workspace/misc/pixie/pixie/stdlib.pxi at 511:10\n  ([x y] (-div x y))\n         ^" "in pixie function \n" "in <unknown> at 1:1\n(/ 0 0)\n^")

user => (trace *e)
("Divide by zero" "in internal function _div\n" "in /Users/cmeier/workspace/misc/pixie/pixie/stdlib.pxi at 511:10\n  ([x y] (-div x y))\n         ^" "in pixie function \n" "in <unknown> at 1:1\n(/ 0 0)\n^")

```

`seq` was also extended to Runtime Exceptions.


@halgari Let me know if this is what you were thinking of..









