### PR TITLE
added an identity hash method to Object

### DIFF
--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -1,3 +1,4 @@
+from rpython.rlib.objectmodel import compute_identity_hash
 import rpython.rlib.jit as jit
 
 class Object(object):
@@ -20,6 +21,10 @@ class Object(object):
     def r_uint_val(self):
         affirm(False, u"Expected Number, not " + self.type().name())
         return 0
+
+    def hash(self):
+        import pixie.vm.rt as rt
+        return rt.wrap(compute_identity_hash(self))
 
     def promote(self):
         return self

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -105,8 +105,14 @@ def default_str(x):
     assert isinstance(tp, Type)
     return rt.wrap(u"<inst " + tp._name + u">")
 
+def default_hash(x):
+    tp = x.type()
+    assert isinstance(tp, Type)
+    return x.hash()
+
 _str.set_default_fn(wrap_fn(default_str))
 _repr.set_default_fn(wrap_fn(default_str))
+_hash.set_default_fn(wrap_fn(default_hash))
 
 _meta.set_default_fn(wrap_fn(lambda x: nil))
 
@@ -247,8 +253,6 @@ def _(self):
 @as_var("hash")
 def __hash(x):
     return rt._hash(x)
-
-
 
 _count_driver = jit.JitDriver(name="pixie.stdlib.count",
                               greens=["tp"],

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -106,8 +106,6 @@ def default_str(x):
     return rt.wrap(u"<inst " + tp._name + u">")
 
 def default_hash(x):
-    tp = x.type()
-    assert isinstance(tp, Type)
     return x.hash()
 
 _str.set_default_fn(wrap_fn(default_str))

--- a/tests/pixie/tests/test-object.pxi
+++ b/tests/pixie/tests/test-object.pxi
@@ -1,0 +1,6 @@
+(ns pixie.tests.test-object
+  (require pixie.test :as t))
+
+(t/deftest test-hash
+  (t/assert= (hash (var foo)) (hash (var foo)))
+  (t/assert  (not= (hash (var foo)) (hash (var bar)))))


### PR DESCRIPTION
I'm not sure if this is what you were thinking in #196 but heres an attempt. It wasn't possible to make `pixie.object.Object` extend `IObject` because it has no type and I wasn't sure if that was the best way to approach the problem, so I have just added a check to see if something satisfies `IObject` otherwise `obj_hash` is called.