### PR TITLE
Keyword with current namespace shortcut ::

### DIFF
--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -71,7 +71,7 @@ class PromptReader(PlatformReader):
 
     def read(self):
         if self._string_reader is None:
-            result = _readline(str(rt.name(compiler.NS_VAR.deref())) + " => ")
+            result = _readline(str(rt.name(rt.ns.deref())) + " => ")
             if result == u"":
                 raise EOFError()
             self._string_reader = StringReader(result)
@@ -269,10 +269,21 @@ class QuoteReader(ReaderHandler):
 
 class KeywordReader(ReaderHandler):
     def invoke(self, rdr, ch):
-        itm = read(rdr, True)
-        affirm(isinstance(itm, Symbol), u"Can't keyword quote a non-symbol")
+        nms = u""
+        ch = rdr.read()
+        if ch == u":":
+            itm = read(rdr, True)
+            nms = rt.ns.deref().name()
+        else:
+            rdr.unread(ch)
+            itm = read(rdr, True)
 
-        return keyword(rt.name(itm), rt.namespace(itm))
+        affirm(isinstance(itm, Symbol), u"Can't keyword quote a non-symbol")
+        if nms:
+            affirm(rt.namespace(itm) is None, u"Kewyword cannot have two namespaces")
+            return keyword(rt.name(itm), nms)
+        else:
+            return keyword(rt.name(itm), rt.namespace(itm))
 
 class LiteralStringReader(ReaderHandler):
     def invoke(self, rdr, ch):

--- a/pixie/vm/rt.py
+++ b/pixie/vm/rt.py
@@ -12,6 +12,7 @@ def init():
     from pixie.vm.primitives import nil, true, false
     from pixie.vm.string import String
     from pixie.vm.object import Object
+    from pixie.vm.compiler import NS_VAR
 
     _type_registry.set_registry(code._ns_registry)
 
@@ -150,6 +151,8 @@ def init():
     init_vars = [u"load-paths"]
     for x in init_vars:
         globals()[py_str(code.munge(x))] = code.intern_var(u"pixie.stdlib", x)
+
+    globals()[py_str(code.munge(u"ns"))] = NS_VAR
 
     globals()["__inited__"] = True
 

--- a/tests/pixie/tests/test-keywords.pxi
+++ b/tests/pixie/tests/test-keywords.pxi
@@ -11,7 +11,8 @@
 
 (t/deftest keyword-namespace
   (t/assert= (namespace :foo/bar) "foo")
-  (t/assert= (namespace :cat/dog) "cat"))
+  (t/assert= (namespace :cat/dog) "cat")
+  (t/assert= (namespace ::foo) "pixie.tests.test-keywords"))
 
 
 (t/deftest keyword-equality


### PR DESCRIPTION
```clojure
Pixie 0.1 - Interactive REPL
(darwin_x86_64, clang)
:exit-repl or Ctrl-D to quit
----------------------------
user => :foo
:foo
user => ::foo
:user/foo
```

Feedback is always welcome