### PR TITLE
compile tests before running to validate pxic code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
 
 script:
   - make PYTHON=python build
+  - make compile_src
+  - make compile_tests
   - make run_built_tests
 
 before_install:

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -337,6 +337,11 @@
   (fn [v]
     (apply str "(" (conj (transduce (comp (map -repr) (interpose " ")) conj v) ")"))))
 
+(extend -hash PersistentList
+  (fn [v]
+    (transduce ordered-hash-reducing-fn v)))
+
+
 (extend -str LazySeq
   (fn [v]
     (apply str "(" (conj (transduce (interpose " ") conj v) ")"))))


### PR DESCRIPTION
As we use ffi-infer more and more, it's critical that we support pxic so that we can pre-compile files. So this pre-compiles all files before testing, to ensure that we don't break pxic support sometime in the future. 