### PR TITLE
implement doc string support for native functions

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1273,11 +1273,13 @@ and implements IAssociative, ILookup and IObject."
   {:doc "Returns the documentation of the given value."
    :added "0.1"}
   [v]
+
   (let [vr (resolve v)
         x (if vr @vr)
         doc (get (meta x) :doc)
         has-doc? (if doc true (get (meta x) :signatures))]
     (cond
+     (satisfies? IDoc x) (-doc x)
      has-doc? (let [sigs (get (meta x) :signatures)
                     examples (get (meta x) :examples)
                     indent (fn [s]

--- a/pixie/vm/code.py
+++ b/pixie/vm/code.py
@@ -172,7 +172,7 @@ class NativeFn(BaseCode):
     """Wrapper for a native function"""
     _type = object.Type(u"pixie.stdlib.NativeFn")
 
-    def __init__(self):
+    def __init__(self, doc=None):
         BaseCode.__init__(self)
 
     def type(self):
@@ -807,11 +807,12 @@ CO_VARARGS = 0x4
 
 def wrap_fn(fn, tp=object.Object):
     """Converts a native Python function into a pixie function."""
+    docstring = unicode(fn.__doc__) if fn.__doc__ else u""
     def as_native_fn(f):
-        return type("W" + fn.__name__, (NativeFn,), {"inner_invoke": f})()
+        return type("W" + fn.__name__, (NativeFn,), {"inner_invoke": f, "_doc": docstring})()
 
     def as_variadic_fn(f):
-        return type("W" + fn.__name__[:len("__args")], (NativeFn,), {"inner_invoke": f})()
+        return type("W" + fn.__name__[:len("__args")], (NativeFn,), {"inner_invoke": f, "_doc": docstring})()
 
     code = fn.func_code
     if fn.__name__.endswith("__args"):

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -43,6 +43,8 @@ defprotocol("pixie.stdlib", "IStack", ["-push", "-pop"])
 
 defprotocol("pixie.stdlib", "IFn", ["-invoke"])
 
+defprotocol("pixie.stdlib", "IDoc", ["-doc"])
+
 IVector = as_var("pixie.stdlib", "IVector")(Protocol(u"IVector"))
 
 IMap = as_var("pixie.stdlib", "IMap")(Protocol(u"IMap"))
@@ -799,5 +801,11 @@ def _seq(self):
 
 @as_var("ex-msg")
 def ex_msg(e):
+    """Returns the message contained in an exception"""
     assert isinstance(e, RuntimeException)
     return e._data
+
+@extend(_doc, code.NativeFn._type)
+def _doc(self):
+    assert isinstance(self, code.NativeFn)
+    return rt.wrap(self._doc)


### PR DESCRIPTION
With this PR, any function that uses `@as_var` or `@wrap_fn` will have its python doc string pulled in as a pixie doc string. Let's start documenting native functions!