### PR TITLE
Fix line comment bug and improve reader tests

### DIFF
--- a/pixie/vm/test/test_reader.py
+++ b/pixie/vm/test/test_reader.py
@@ -4,6 +4,8 @@ from pixie.vm.cons import Cons
 from pixie.vm.numbers import Integer
 from pixie.vm.symbol import symbol, Symbol
 from pixie.vm.persistent_vector import PersistentVector
+from pixie.vm.persistent_hash_map import PersistentHashMap
+from pixie.vm.primitives import nil
 import pixie.vm.rt as rt
 import unittest
 
@@ -17,7 +19,14 @@ data = {u"(1 2)": (1, 2,),
         u"(platform+ 1 2)": (symbol(u"platform+"), 1, 2),
         u"[42 43 44]": [42, 43, 44],
         u"(1 2 ; 7 8 9\n3)": (1, 2, 3,),
-        u"(1 2 ; 7 8 9\r\n3)": (1, 2, 3,)}
+        u"(1 2 ; 7 8 9\r\n3)": (1, 2, 3,),
+        u"(1 2 ; 7 8 9\r\n)": (1, 2,),
+        u"(1 2 ; 7 8 9\n)": (1, 2,),
+        u"[1 2 ; 7 8 9\n]": [1, 2,],
+        u"(1 2; 7 8 9\n)": (1, 2,),
+        u";foo\n(1 2; 7 8 9\n)": (1, 2,),
+        u"{\"foo\" 1 ;\"bar\" 2\n\"baz\" 3}": {"foo": 1, "baz": 3},
+        u"{\"foo\" ; \"bar\" 2\n1 \"baz\" 3}": {"foo": 1, "baz": 3}}
 
 class TestReader(unittest.TestCase):
     def _compare(self, frm, to):
@@ -27,6 +36,7 @@ class TestReader(unittest.TestCase):
             for x in to:
                 self._compare(frm.first(), x)
                 frm = frm.next()
+            assert frm == nil
         elif isinstance(to, int):
             assert isinstance(frm, Integer)
             assert frm._int_val == to
@@ -38,9 +48,15 @@ class TestReader(unittest.TestCase):
         elif isinstance(to, list):
             assert isinstance(frm, PersistentVector)
 
-            for x in range(len(to)):
+            for x in range(max(len(to), rt._count(frm)._int_val)):
                 self._compare(rt.nth(frm, rt.wrap(x)), to[x])
 
+        elif isinstance(to, dict):
+            assert isinstance(frm, PersistentHashMap)
+            for key in dict.keys(to):
+                self._compare(frm.val_at(rt.wrap(key), ""), to[key])
+
+            assert rt._count(frm)._int_val == len(dict.keys(to))
         else:
             raise Exception("Don't know how to handle " + str(type(to)))
 


### PR DESCRIPTION
Previously, code like
```
(1 2 3 ;foo
)
```
would fail to parse, because LineCommentReader would attempt to return
the next form, which was `)`, causing an error.

To fix this I changed the semantics of `read` to allow it to not return
a form at all (signalled by returning the reader itself, as in
https://github.com/clojure/tools.reader), for situations like `;`.
Unsure if this is the best approach to fixing, open to discussion.
Another option could be to treat comments as whitespace.

Also, the reader tests had some cases where they wouldn't verify the
input properly, so I fixed those as well.