### PR TITLE
Allow terminating macro characters as character literals

### DIFF
--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -329,7 +329,7 @@ class LiteralStringReader(ReaderHandler):
                 acc.append(v)
 
 def read_token(rdr):
-    acc = u""
+    acc = rdr.read()
     while True:
         ch = rdr.read()
         if is_whitespace(ch) or is_terminating_macro(ch):

--- a/pixie/vm/test/test_reader.py
+++ b/pixie/vm/test/test_reader.py
@@ -3,6 +3,7 @@ from pixie.vm.object import Object
 from pixie.vm.cons import Cons
 from pixie.vm.numbers import Integer
 from pixie.vm.symbol import symbol, Symbol
+from pixie.vm.string import Character
 from pixie.vm.persistent_vector import PersistentVector
 from pixie.vm.persistent_hash_map import PersistentHashMap
 from pixie.vm.primitives import nil
@@ -26,7 +27,11 @@ data = {u"(1 2)": (1, 2,),
         u"(1 2; 7 8 9\n)": (1, 2,),
         u";foo\n(1 2; 7 8 9\n)": (1, 2,),
         u"{\"foo\" 1 ;\"bar\" 2\n\"baz\" 3}": {"foo": 1, "baz": 3},
-        u"{\"foo\" ; \"bar\" 2\n1 \"baz\" 3}": {"foo": 1, "baz": 3}}
+        u"{\"foo\" ; \"bar\" 2\n1 \"baz\" 3}": {"foo": 1, "baz": 3},
+        u"(\\a)": (Character(ord("a")),),
+        u"(\\))": (Character(ord(")")),),
+        u"(\\()": (Character(ord("(")),),
+        u"(\\;)": (Character(ord(";")),)}
 
 class TestReader(unittest.TestCase):
     def _compare(self, frm, to):
@@ -57,6 +62,11 @@ class TestReader(unittest.TestCase):
                 self._compare(frm.val_at(rt.wrap(key), ""), to[key])
 
             assert rt._count(frm)._int_val == len(dict.keys(to))
+
+        elif isinstance(to, Character):
+            assert isinstance(frm, Character)
+            assert to._char_val == frm._char_val
+
         else:
             raise Exception("Don't know how to handle " + str(type(to)))
 


### PR DESCRIPTION
Previously
```
(def a \))
```
would fail to parse. This commit fixes that by making sure the LiteralCharacterReader always reads at least one character.

I saw in another PR you said you've sort of abandoned these tests - is there a more appropriate place to add tests for something like this?