### PR TITLE
Add more comments tests and fix case I missed

### DIFF
--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -623,7 +623,9 @@ class SetReader(ReaderHandler):
                 return acc
 
             rdr.unread()
-            acc = acc.conj(read_inner(rdr, True))
+            itm = read_inner(rdr, True, always_return_form=False)
+            if itm != rdr:
+                acc = acc.conj(itm)
 
 dispatch_handlers = {
     u"{":  SetReader(),

--- a/tests/pixie/tests/test-readeval.pxi
+++ b/tests/pixie/tests/test-readeval.pxi
@@ -14,6 +14,7 @@
   (t/assert= (read-string "\"fo\\\\o\"") "fo\\o")
   (t/assert= (read-string "false") false)
   (t/assert= (read-string "true") true)
+  (t/assert= (read-string "#{1 2 3}") #{1 2 3})
   (t/assert= (read-string "(foo (bar (baz)))") '(foo (bar (baz)))))
 
 (t/deftest test-list-unclosed-list-fail
@@ -57,4 +58,8 @@
                     (read-string "\"foo")))
 
 (t/deftest test-comments-in-forms
-  (t/assert= (read-string "(foo ; a comment\n )") '(foo)))
+  (t/assert= (read-string "(foo ; a comment\n )") '(foo))
+  (t/assert= (read-string "[foo ; a comment\n ]") '[foo])
+  (t/assert= (read-string "{:foo :bar ; a comment\n }") '{:foo :bar})
+  (t/assert= (read-string "#{:foo ; a comment\n }") '#{:foo})
+  (t/assert= (read-string "{:foo ; a comment\n :bar }") '{:foo :bar}))


### PR DESCRIPTION
I fixed the comment problem for lists, vectors, and maps, but missed sets, so I've fixed that now, sorry about that.

I also added a couple tests.