### PR TITLE
adds a async namespace. Includes futures and promises

### DIFF
--- a/pixie/async.pxi
+++ b/pixie/async.pxi
@@ -5,7 +5,6 @@
 (deftype Promise [val pending-callbacks delivered?]
   IDeref
   (-deref [self]
-    (println "waiting... " delivered?)
     (if delivered?
       val
       (do
@@ -15,11 +14,9 @@
                             (st/-run-later (partial st/run-and-process k v)))))))))
   IFn
   (-invoke [self v]
-    (println "delivering....")
     (assert (not delivered?) "Can only deliver a promise once")
     (set-field! self :val v)
     (set-field! self :delivered? true)
-    (println  @pending-callbacks)
     (doseq [f @pending-callbacks]
       (f v))
     (reset! pending-callbacks nil)

--- a/pixie/async.pxi
+++ b/pixie/async.pxi
@@ -1,0 +1,34 @@
+(ns pixie.async
+  (require pixie.stacklets :as st))
+
+
+(deftype Promise [val pending-callbacks delivered?]
+  IDeref
+  (-deref [self]
+    (println "waiting... " delivered?)
+    (if delivered?
+      val
+      (do
+        (st/call-cc (fn [k]
+                   (swap! pending-callbacks conj
+                          (fn [v]
+                            (st/-run-later (partial st/run-and-process k v)))))))))
+  IFn
+  (-invoke [self v]
+    (println "delivering....")
+    (assert (not delivered?) "Can only deliver a promise once")
+    (set-field! self :val v)
+    (set-field! self :delivered? true)
+    (println  @pending-callbacks)
+    (doseq [f @pending-callbacks]
+      (f v))
+    (reset! pending-callbacks nil)
+    nil))
+
+(defn promise []
+  (->Promise nil (atom []) false))
+
+(defmacro future [& body]
+  `(let [p# (promise)]
+     (st/spawn (p# (do ~@body)))
+     p#))

--- a/pixie/stacklets.pxi
+++ b/pixie/stacklets.pxi
@@ -118,33 +118,8 @@
   (with-stacklets
     (f)))
 
-
-(deftype Promise [val pending-callbacks delivered?]
-  IDeref
-  (-deref [self]
-    (if delivered?
-      val
-      (do
-        (call-cc (fn [k]
-                   (swap! pending-callbacks conj
-                          (fn [v]
-                            (-run-later (partial run-and-process k v)))))))))
-  IFn
-  (-invoke [self v]
-    (assert (not delivered?) "Can only deliver a promise once")
-    (set-field! self :val v)
-    (println  @pending-callbacks)
-    (doseq [f @pending-callbacks]
-      (f v))
-    (reset! pending-callbacks nil)
-    nil))
-
-(defn promise []
-  (->Promise nil (atom []) false))
-
 (defprotocol IThreadPool
   (-execute [this work-fn]))
-
 
 ;; Super basic Thread Pool, yes, this should be improved
 

--- a/tests/pixie/tests/test-async.pxi
+++ b/tests/pixie/tests/test-async.pxi
@@ -1,0 +1,15 @@
+(ns pixie.tests.test-async
+  (require pixie.stacklets :as st)
+  (require pixie.async :as async :refer :all)
+  (require pixie.test :as t :refer :all))
+
+
+(deftest test-future-deref
+  (let [f (future 42)]
+    (assert= @f 42)))
+
+(deftest test-future-deref-chain
+  (let [f1 (future 42)
+        f2 (future @f1)
+        f3 (future @f2)]
+    (assert= @f3 42)))


### PR DESCRIPTION
PROBLEM: It is currently hard to communicate between stacklets, and the promises functionality is hidden inside a rather obscure ns

SOLUTION: expose pixie.async, and include futures and promises. 