### PR TITLE
fixed dynamic vars for stacklets

### DIFF
--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -32,13 +32,13 @@ FILE_KW = keyword(u"file")
 
 GEN_SYM_ENV = code.intern_var(u"pixie.stdlib.reader", u"*gen-sym-env*")
 GEN_SYM_ENV.set_dynamic()
-GEN_SYM_ENV.set_value(EMPTY_MAP)
+GEN_SYM_ENV.set_root(EMPTY_MAP)
 
 ARG_AMP = symbol(u"&")
 ARG_MAX = keyword(u"max-arg")
 ARG_ENV = code.intern_var(u"pixie.stdlib.reader", u"*arg-env*")
 ARG_ENV.set_dynamic()
-ARG_ENV.set_value(nil)
+ARG_ENV.set_root(nil)
 
 class PlatformReader(object.Object):
     _type = object.Type(u"PlatformReader")

--- a/pixie/vm/rt.py
+++ b/pixie/vm/rt.py
@@ -49,6 +49,7 @@ def init():
     import sys
     #sys.setrecursionlimit(10000)  # Yeah we blow the stack sometimes, we promise it's not a bug
 
+    import pixie.vm.code as code
     import pixie.vm.numbers as numbers
     import pixie.vm.bits
     import pixie.vm.interpreter
@@ -70,8 +71,6 @@ def init():
     import pixie.vm.threads
     import pixie.vm.string_builder
     import pixie.vm.stacklet
-
-    numbers.init()
 
     @specialize.argtype(0)
     def wrap(x):
@@ -145,7 +144,7 @@ def init():
     # stacklet.with_stacklets(run_load_stdlib)
 
     init_fns = [u"reduce", u"get", u"reset!", u"assoc", u"key", u"val", u"keys", u"vals", u"vec", u"load-file", u"compile-file",
-                u"load-ns", u"hashmap"]
+                u"load-ns", u"hashmap", u"cons", u"-assoc", u"-val-at"]
     for x in init_fns:
         globals()[py_str(code.munge(x))] = unwrap(code.intern_var(u"pixie.stdlib", x))
 
@@ -158,6 +157,10 @@ def init():
     globals()["__inited__"] = True
 
     globals()["is_true"] = lambda x: False if x is false or x is nil or x is None else True
+
+    numbers.init()
+    code.init()
+
 
 
 

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -813,3 +813,17 @@ def ex_msg(e):
 def _doc(self):
     assert isinstance(self, code.NativeFn)
     return rt.wrap(self._doc)
+
+
+@as_var("-get-current-var-frames")
+def _get_current_var_frames(self):
+    """(-get-current-var-frames)
+       Returns the current var frames, will be a cons list of hash maps containing mappings of vars to dynamic values"""
+    return code._dynamic_vars.get_current_frames()
+
+@as_var("-set-current-var-frames")
+def _set_current_var_frames(self, frames):
+    """(-set-current-var-frames frames)
+       Sets the current var frames. Frames should be a cons list of hashmaps containing mappings of vars to dynamic
+       values. Setting this value to anything but this data format will cause undefined errors."""
+    code._dynamic_vars.set_current_frames(frames)

--- a/tests/pixie/tests/test-async.pxi
+++ b/tests/pixie/tests/test-async.pxi
@@ -13,3 +13,17 @@
         f2 (future @f1)
         f3 (future @f2)]
     (assert= @f3 42)))
+
+(def *some-var* 0)
+(set-dynamic! (var *some-var*))
+
+(deftest test-dynamic-var-propagation
+  (set! (var *some-var*) 0)
+  (assert= *some-var* 0)
+  (let [fr @(future (do (println "running")
+                       (let [old-val *some-var*]
+                         (set! (var *some-var*) 42)
+                         [old-val *some-var*])))]
+
+    (assert= fr [0 42])
+    (assert= *some-var* 0)))


### PR DESCRIPTION
PROBLEM: dynamic vars are not set on a per-stacklet basis. 

SOLUTION: set and reset the stacklet dynamic vars around each invocation of call-cc