### PR TITLE
Allow for importing CVoidPs from libraries

### DIFF
--- a/pixie/ffi-infer.pxi
+++ b/pixie/ffi-infer.pxi
@@ -62,6 +62,10 @@
   [{:keys [name]}]
   (str "PixieChecker::DumpType<__typeof__(" name ")>();"))
 
+(defmethod emit-infer-code :global
+  [_]
+  (str "std::cout <<\"[]\" << std::endl;"))
+
 
 (defn start-string []
   (str (apply str (map (fn [i]
@@ -79,6 +83,7 @@
   " std::cout << \"]\" << std::endl;
 return 0;
       }")
+
 
 ;; To Ctype conversion
 
@@ -130,6 +135,10 @@ return 0;
 (defmethod generate-code :const
   [{:keys [name]} {:keys [value type]}]
   `(def ~(symbol name) ~value))
+
+(defmethod generate-code :global
+  [{:keys [name]} _]
+  `(def ~(symbol name) (ffi-voidp *library* ~(str name))))
 
 
 
@@ -226,6 +235,10 @@ return 0;
 
 (defmacro defccallback [nm]
   `(swap! *bodies* conj (assoc {:op :callback}
+                          :name ~(name nm))))
+
+(defmacro defglobal [nm]
+  `(swap! *bodies* conj (assoc {:op :global}
                           :name ~(name nm))))
 
 

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -196,6 +196,13 @@ def _ffi_fn__args(args):
     f = FFIFn(lib, rt.name(nm), new_args, ret_type, is_variadic)
     return f
 
+@as_var("ffi-voidp")
+def _ffi_voidp(lib, nm):
+    affirm(isinstance(lib, ExternalLib), u"First argument to ffi-voidp should be an external library")
+    name = rt.name(nm)
+    return VoidP(lib.get_fn_ptr(name))
+
+
 
 
 


### PR DESCRIPTION
PROBLEM: Currently we have no way of importing non-function symbols from dynamic libraries

SOLUTION: Extends ffi-infer to add defglobal and adds `(ffi-voidp library name)` to import voidp symbols from libraries