### PR TITLE
Implement map without using iterators, fixes #242

### DIFF
--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -6,6 +6,14 @@
     (doseq [v vs]
       (t/assert= (identity v) v))))
 
+(t/deftest test-map
+  (t/assert= (map inc [1 2 3]) [2 3 4])
+  (t/assert= (map + [1 2 3] [4 5 6]) [5 7 9])
+  (t/assert= (map + [1 2 3] [4 5 6] [7 8 9]) [12 15 18])
+  (let [value (map identity [1 2 3])]
+    (t/assert= (seq value) [1 2 3])
+    (t/assert= (seq value) [1 2 3])))
+
 (t/deftest test-mapcat
   (t/assert= (mapcat identity []) [])
   (t/assert= (mapcat first [[[1 2]] [[3] [:not :present]] [[4 5 6]]]) [1 2 3 4 5 6]))


### PR DESCRIPTION
The fact that map was implemented with iterators caused the following to
happen:

```
user => (def sqr #(* % %))
<inst pixie.stdlib.Var>
user => (def sqrs (map sqr [1 2 3]))
<inst pixie.stdlib.Var>
user => sqrs
<inst pixie.stdlib.ShallowContinuation>
user => (vec sqrs)
[1 4 9]
user => (vec sqrs)
[]
```

This commit implements map differently and adds tests to ensure
that it behaves as intended.

The implementation is pretty similar to the [CLJS one](https://github.com/clojure/clojurescript/blob/master/src/cljs/cljs/core.cljs#L4059-L4065), there are just a
few things that aren't available (since `map` is defined earlier in the
pixie stdlib than the CLJS core).