### PR TITLE
Make the REPL history vars work

### DIFF
--- a/pixie/repl.pxi
+++ b/pixie/repl.pxi
@@ -21,7 +21,9 @@
       (try (let [form (read rdr false)]
              (if (= form eof)
                (exit 0)
-               (println (eval form))))
+               (let [x (eval form)]
+                 (pixie.stdlib/-push-history x)
+                 (println x))))
            (catch ex
                (println "ERROR: \n" ex)))
       (recur))))

--- a/pixie/repl.pxi
+++ b/pixie/repl.pxi
@@ -25,5 +25,6 @@
                  (pixie.stdlib/-push-history x)
                  (println x))))
            (catch ex
-               (println "ERROR: \n" ex)))
+             (pixie.stdlib/-set-*e ex)
+             (println "ERROR: \n" ex)))
       (recur))))

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2186,3 +2186,8 @@ Expands to calls to `extend-type`."
                   (when (branch? node)
                     (mapcat walk (children node))))))]
     (walk root)))
+
+(defn -push-history [x]
+  (def *3 *2)
+  (def *2 *1)
+  (def *1 x))

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2191,3 +2191,6 @@ Expands to calls to `extend-type`."
   (def *3 *2)
   (def *2 *1)
   (def *1 x))
+
+(defn -set-*e [e]
+  (def *e e))


### PR DESCRIPTION
Currently at some point `*1`, `*2`, `*3` and `*e` are all defined to `nil` (Where is the code that does that?), and stay `nil` when evaluating stuff in the REPL. This PR makes them work like they were presumably intended to.

[Random remark: It looks like you cannot `def` a var in a different namespace than the current one. This is probably a feature :).]