### PR TITLE
Print stuff in the repl using `prn`, not `println`

### DIFF
--- a/pixie/repl.pxi
+++ b/pixie/repl.pxi
@@ -23,7 +23,7 @@
                (exit 0)
                (let [x (eval form)]
                  (pixie.stdlib/-push-history x)
-                 (println x))))
+                 (prn x))))
            (catch ex
              (pixie.stdlib/-set-*e ex)
              (println "ERROR: \n" ex)))


### PR DESCRIPTION
You'll want this for strings, for example.