### PR TITLE
Implement -seq for sets the same way as maps

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -959,7 +959,9 @@ If further arguments are passed, invokes the method named by symbol, passing the
         (fn [v]
           (transduce cat unordered-hash-reducing-fn v)))
 
-(extend -seq PersistentHashSet (fn [self] (seq (iterator self))))
+(extend -seq PersistentHashSet
+        (fn [s]
+          (reduce conj nil s)))
 
 (extend -str PersistentHashSet
         (fn [s]


### PR DESCRIPTION
Sets were using iterators (which were mentioned should be removed in #242)
instead of building a list like maps do, and I guess some of the iterator
code doesn't work properly for maps, because executing `(seq #{4 7})`
causes a segfault without this patch.

I'm not really familar with the implementation of iterators over maps,
but this is sort of an interesting bug because I've only been able to
reproduce it with sets that have `#{4 7}` as a subset.

I'm happy to go through and remove the rest of the iterator code if
you're sure it should be taken out. 