### PR TITLE
clojure style :require

### DIFF
--- a/pixie/async.pxi
+++ b/pixie/async.pxi
@@ -1,5 +1,5 @@
 (ns pixie.async
-  (require pixie.stacklets :as st))
+  (:require [pixie.stacklets :as st]))
 
 
 (deftype Promise [val pending-callbacks delivered?]

--- a/pixie/channels.pxi
+++ b/pixie/channels.pxi
@@ -1,6 +1,6 @@
 (ns pixie.channels
-  (require pixie.stacklets :as st)
-  (require pixie.buffers :as b))
+  (:require [pixie.stacklets :as st]
+            [pixie.buffers :as b]))
 
 (defprotocol ICancelable
   (-canceled? [this] "Determines if a request (such as a callback) that can be canceled")

--- a/pixie/csp.pxi
+++ b/pixie/csp.pxi
@@ -1,7 +1,7 @@
 (ns pixie.csp
-  (require pixie.stacklets :as st)
-  (require pixie.buffers :as b)
-  (require pixie.channels :as chans))
+  (:require [pixie.stacklets :as st]
+            [pixie.buffers :as b]
+            [pixie.channels :as chans]))
 
 (def chan chans/chan)
 

--- a/pixie/ffi-infer.pxi
+++ b/pixie/ffi-infer.pxi
@@ -1,5 +1,5 @@
 (ns pixie.ffi-infer
-  (require pixie.io-blocking :as io))
+  (:require [pixie.io-blocking :as io]))
 
 
 (defn -add-rel-path [rel]

--- a/pixie/fs.pxi
+++ b/pixie/fs.pxi
@@ -1,6 +1,6 @@
 (ns pixie.fs
-  (require pixie.path :as path)
-  (require pixie.string :as string))
+  (:require [pixie.path :as path]
+            [pixie.string :as string]))
 
 
 (defprotocol IFSPath

--- a/pixie/io-blocking.pxi
+++ b/pixie/io-blocking.pxi
@@ -1,5 +1,5 @@
 (ns pixie.io-blocking
-  (require pixie.streams :as st :refer :all))
+  (:require [pixie.streams :as st :refer :all]))
 
 
 (def fopen (ffi-fn libc "fopen" [CCharP CCharP] CVoidP))

--- a/pixie/io.pxi
+++ b/pixie/io.pxi
@@ -1,10 +1,10 @@
 (ns pixie.io
-  (require pixie.streams :as st :refer :all)
-  (require pixie.io-blocking :as io-blocking)
-  (require pixie.uv :as uv)
-  (require pixie.stacklets :as st)
-  (require pixie.ffi :as ffi)
-  (require pixie.ffi-infer :as ffi-infer))
+  (:require [pixie.streams :as st :refer :all]
+            [pixie.io-blocking :as io-blocking]
+            [pixie.uv :as uv]
+            [pixie.stacklets :as st]
+            [pixie.ffi :as ffi]
+            [pixie.ffi-infer :as ffi-infer]))
 
 (defmacro defuvfsfn [nm args return]
   `(defn ~nm ~args

--- a/pixie/math.pxi
+++ b/pixie/math.pxi
@@ -1,5 +1,5 @@
 (ns pixie.math
-  (require pixie.ffi-infer :as i))
+  (:require [pixie.ffi-infer :as i]))
 
 (i/with-config {:library "m"
                 :cxx-flags ["-lm"]

--- a/pixie/repl.pxi
+++ b/pixie/repl.pxi
@@ -1,7 +1,7 @@
 (ns pixie.repl
-  (require pixie.stacklets :as st)
-  (require pixie.io :as io)
-  (require pixie.ffi-infer :as f))
+  (:require [pixie.stacklets :as st]
+            [pixie.io :as io]
+            [pixie.ffi-infer :as f]))
 
 (f/with-config {:library "edit"
                 :includes ["editline/readline.h"]}

--- a/pixie/stacklets.pxi
+++ b/pixie/stacklets.pxi
@@ -1,6 +1,6 @@
 (ns pixie.stacklets
-  (require pixie.uv :as uv)
-  (require pixie.ffi :as ffi))
+  (:require [pixie.uv :as uv]
+            [pixie.ffi :as ffi]))
 
 ;; If we don't do this, compiling this file doesn't work since the def will clear out
 ;; the existing value.

--- a/pixie/string.pxi
+++ b/pixie/string.pxi
@@ -1,5 +1,5 @@
 (ns pixie.string
-  (require pixie.string.internal :as si))
+  (:require [pixie.string.internal :as si]))
 
 ; reexport native string functions
 (def substring si/substring)

--- a/pixie/test.pxi
+++ b/pixie/test.pxi
@@ -1,6 +1,6 @@
 (ns pixie.test
-  (require pixie.string :as s)
-  (require pixie.fs :as fs))
+  (:require [pixie.string :as s]
+            [pixie.fs :as fs]))
 
 (def tests (atom {}))
 

--- a/pixie/uv.pxi
+++ b/pixie/uv.pxi
@@ -1,5 +1,5 @@
 (ns pixie.uv
-  (require pixie.ffi-infer :as f))
+  (:require [pixie.ffi-infer :as f]))
 
 (f/with-config  {:library "uv"
                 :includes ["uv.h"]}

--- a/tests/pixie/tests/test-async.pxi
+++ b/tests/pixie/tests/test-async.pxi
@@ -1,7 +1,7 @@
 (ns pixie.tests.test-async
-  (require pixie.stacklets :as st)
-  (require pixie.async :as async :refer :all)
-  (require pixie.test :as t :refer :all))
+  (:require [pixie.stacklets :as st]
+            [pixie.async :as async :refer :all]
+            [pixie.test :as t :refer :all]))
 
 
 (deftest test-future-deref

--- a/tests/pixie/tests/test-buffers.pxi
+++ b/tests/pixie/tests/test-buffers.pxi
@@ -1,7 +1,6 @@
 (ns pixie.tests.test-buffers
-  (require pixie.test :refer :all)
-  (require pixie.buffers :refer :all))
-
+  (:require [pixie.test :refer :all]
+            [pixie.buffers :refer :all]))
 
 (deftest test-adding-and-removing-from-buffer
   (let [buffer (ring-buffer 10)]

--- a/tests/pixie/tests/test-channels.pxi
+++ b/tests/pixie/tests/test-channels.pxi
@@ -1,8 +1,8 @@
 (ns pixie.tests.test-channels
-  (require pixie.test :refer :all)
-  (require pixie.channels :refer :all)
-  (require pixie.async :refer :all)
-  (require pixie.stacklets :as st))
+  (:require [pixie.test :refer :all]
+            [pixie.channels :refer :all]
+            [pixie.async :refer :all]
+            [pixie.stacklets :as st]))
 
 
 (deftest simple-read-and-write


### PR DESCRIPTION
Adds clojure style require syntax to ns macro. The syntax is optional so the old many-require-statement syntax should continue to work. Not all namespaces have been updated to the new syntax.