### PR TITLE
Ignore all .pxics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ pixie-vm
 .idea
 lib
 include
-pixie/*.pxic
+*.pxic
 test.tmp


### PR DESCRIPTION
The old glob didn't catch `pixie/streams/utf8.pxic`.