### PR TITLE
Remove some lingering iterator stuff

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -309,7 +309,6 @@
 (extend -reduce Nil (fn [self f init] init))
 (extend -hash Nil (fn [self] 100000))
 (extend -with-meta Nil (fn [self _] nil))
-(extend -at-end? Nil (fn [_] true))
 (extend -deref Nil (fn [_] nil))
 (extend -contains-key Nil (fn [_ _] false))
 
@@ -396,13 +395,6 @@
     (if v
       1111111
       3333333)))
-
-(def stacklet->lazy-seq
-  (fn [k]
-    (if (-at-end? k)
-      nil
-      (cons (-current k)
-            (lazy-seq* (fn [] (stacklet->lazy-seq (-move-next! k))))))))
 
 (def = -eq)
 
@@ -1391,18 +1383,6 @@ The new value is thus `(apply f current-value-of-atom args)`."
         nil)
     nil
     ~(nth binding 1 nil)))
-
-(defmacro iterate [binding & body]
-  (assert (= 2 (count binding)) "binding and collection required")
-  `(let [i# (iterator ~(second binding))]
-     (loop []
-       (if (at-end? i#)
-         nil
-         (let [~(first binding) (current i#)]
-           ~@body
-           (move-next! i#)
-           (recur))))))
-
 
 (defmacro dotimes
   {:doc "Execute the expressions in the body n times."


### PR DESCRIPTION
Line 312 was causing the stdlib to fail to compile for me and some others:

```
WARNING: Compiling core libs. If you want to modify one of these files delete the .pxic files first
 
 
 
 
./pixie-vm -c pixie/uv.pxi -c pixie/io.pxi -c pixie/stacklets.pxi -c pixie/stdlib.pxi -c pixie/repl.pxi
in internal function run_load_stdlib
 
in internal function load-ns
 
in internal function load-file
 
in internal function load-reader
 
Running: <inst pixie.stdlib.Cons>
in /Users/steveo/dev/other/pixie/pixie/stdlib.pxi at 312:1
(extend -at-end? Nil (fn [_] true))
^
in pixie function _toplevel_
 
in /Users/steveo/dev/other/pixie/pixie/stdlib.pxi at 312:9
(extend -at-end? Nil (fn [_] true))
        ^
RuntimeException: Var -at-end? is undefined
```
(from https://gist.github.com/saolsen/766a6e81d6d350fdb49d)

I think the rest is just unused now.