### PR TITLE
Fix issue #288

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Some planned and implemented features:
     make build_with_jit
     ./pixie-vm
 
+Note: Mac OS X does not come with the build tools required by default. Install the XCode Command Line tools ([Apple Developer Site](http://developer.apple.com)) or install them independently.
+
 
 ## Running the tests
 

--- a/pixie/vm/numbers.py
+++ b/pixie/vm/numbers.py
@@ -134,9 +134,9 @@ def define_num_ops():
                 if op == "_div" and c1 == Integer and c2 == Integer:
                     continue
                 extend_num_op(op, c1, c2, conv1, sym, conv2)
-            extend_num_op("_quot", c1, c2, conv1, "/", conv2, wrap_start = "rt.wrap(math.floor(", wrap_end = "))")
             if c1 != Integer or c2 != Integer:
                     extend_num_op("_rem", c1, c2, conv1, ",", conv2, wrap_start = "rt.wrap(math.fmod(", wrap_end = "))")
+                    extend_num_op("_quot", c1, c2, conv1, "/", conv2, wrap_start = "rt.wrap(math.floor(", wrap_end = "))")
             for (op, sym) in [("_num_eq", "=="), ("_lt", "<"), ("_gt", ">"), ("_lte", "<="), ("_gte", ">=")]:
                 extend_num_op(op, c1, c2, conv1, sym, conv2,
                               wrap_start = "true if ", wrap_end = " else false")

--- a/pixie/vm/numbers.py
+++ b/pixie/vm/numbers.py
@@ -135,7 +135,8 @@ def define_num_ops():
                     continue
                 extend_num_op(op, c1, c2, conv1, sym, conv2)
             extend_num_op("_quot", c1, c2, conv1, "/", conv2, wrap_start = "rt.wrap(math.floor(", wrap_end = "))")
-            extend_num_op("_rem", c1, c2, conv1, ",", conv2, wrap_start = "rt.wrap(math.fmod(", wrap_end = "))")
+            if c1 != Integer or c2 != Integer:
+                    extend_num_op("_rem", c1, c2, conv1, ",", conv2, wrap_start = "rt.wrap(math.fmod(", wrap_end = "))")
             for (op, sym) in [("_num_eq", "=="), ("_lt", "<"), ("_gt", ">"), ("_lte", "<="), ("_gte", ">=")]:
                 extend_num_op(op, c1, c2, conv1, sym, conv2,
                               wrap_start = "true if ", wrap_end = " else false")

--- a/tests/pixie/tests/test-numbers.pxi
+++ b/tests/pixie/tests/test-numbers.pxi
@@ -57,8 +57,8 @@
   (t/assert= "<type pixie.stdlib.Float>" (str (type (rem 7/2 3.0)))))
 
 (t/deftest quot-types
-  (t/assert= "<type pixie.stdlib.Integer>" (str (type (quot 5 3))))
-  (t/assert= "<type pixie.stdlib.Float>" (str (type (quot 5.0 3))))
-  (t/assert= "<type pixie.stdlib.Integer>" (str (type (quot 7/2 3/7))))
-  (t/assert= "<type pixie.stdlib.Float>" (str (type (quot 7/2 3.0)))))
+  (t/assert= Integer (type (quot 5 3)))
+  (t/assert= Float (type (quot 5.0 3)))
+  (t/assert= Integer (type (quot 7/2 3/7)))
+  (t/assert= Float (type (quot 7/2 3.0))))
 

--- a/tests/pixie/tests/test-numbers.pxi
+++ b/tests/pixie/tests/test-numbers.pxi
@@ -49,3 +49,16 @@
 (t/deftest test-float
   (doseq [[x f] [[1 1.0] [3 3.0] [3.333 3.333] [3/2 1.5] [1/7 (/ 1.0 7.0)]]]
     (t/assert= (float x) f)))
+
+(t/deftest rem-types
+  (t/assert= "<type pixie.stdlib.Integer>" (str (type (rem 5 3))))
+  (t/assert= "<type pixie.stdlib.Float>" (str (type (rem 5.0 3))))
+  (t/assert= "<type pixie.stdlib.Ratio>" (str (type (rem 7/2 3))))
+  (t/assert= "<type pixie.stdlib.Float>" (str (type (rem 7/2 3.0)))))
+
+(t/deftest quot-types
+  (t/assert= "<type pixie.stdlib.Integer>" (str (type (quot 5 3))))
+  (t/assert= "<type pixie.stdlib.Float>" (str (type (quot 5.0 3))))
+  (t/assert= "<type pixie.stdlib.Integer>" (str (type (quot 7/2 3/7))))
+  (t/assert= "<type pixie.stdlib.Float>" (str (type (quot 7/2 3.0)))))
+

--- a/tests/pixie/tests/test-numbers.pxi
+++ b/tests/pixie/tests/test-numbers.pxi
@@ -51,10 +51,10 @@
     (t/assert= (float x) f)))
 
 (t/deftest rem-types
-  (t/assert= "<type pixie.stdlib.Integer>" (str (type (rem 5 3))))
-  (t/assert= "<type pixie.stdlib.Float>" (str (type (rem 5.0 3))))
-  (t/assert= "<type pixie.stdlib.Ratio>" (str (type (rem 7/2 3))))
-  (t/assert= "<type pixie.stdlib.Float>" (str (type (rem 7/2 3.0)))))
+  (t/assert= Integer (type (rem 5 3)))
+  (t/assert= Float (type (rem 5.0 3)))
+  (t/assert= Ratio (type (rem 7/2 3)))
+  (t/assert= Float (type (rem 7/2 3.0))))
 
 (t/deftest quot-types
   (t/assert= Integer (type (quot 5 3)))


### PR DESCRIPTION
Only extend the rem operation to use math.fmod if one or both of the
two arguments is not an integer.

Fixes #288 