### PR TITLE
Require that exceptions support filterable data, and update catch to allow filtering on these exceptions

### DIFF
--- a/pixie/vm/code.py
+++ b/pixie/vm/code.py
@@ -179,7 +179,8 @@ class MultiArityFn(BaseCode):
         if self._rest_fn:
             acc.append(unicode(str(self._rest_fn.required_arity())) + u"+")
 
-        runtime_error(u"Wrong number of arguments " + unicode(str(arity)) + u" for function '" + unicode(self._name) + u"'. Expected " + join_last(acc, u"or"))
+        runtime_error(u"Wrong number of arguments " + unicode(str(arity)) + u" for function '" + unicode(self._name) + u"'. Expected " + join_last(acc, u"or"),
+                      u"pixie.stdlib/InvalidArityException")
 
     def get_arities(self):
         return self._arities.keys()
@@ -241,7 +242,8 @@ class Code(BaseCode):
         else:
             runtime_error(u"Invalid number of arguments " + unicode(str(len(args))) 
                           + u" for function '" + unicode(str(self._name)) + u"'. Expected "
-                          + unicode(str(self.get_arity())))
+                          + unicode(str(self.get_arity())),
+                          u":pixie.stdlib/InvalidArityException")
 
     def invoke_with(self, args, this_fn):
         try:

--- a/pixie/vm/custom_types.py
+++ b/pixie/vm/custom_types.py
@@ -49,7 +49,8 @@ class CustomTypeInstance(Object):
     def set_field(self, name, val):
         idx = self._custom_type.get_slot_idx(name)
         if idx == -1:
-            runtime_error(u"Invalid field named " + rt.name(rt.str(name)) + u" on type " + rt.name(rt.str(self.type())))
+            runtime_error(u"Invalid field named " + rt.name(rt.str(name)) + u" on type " + rt.name(rt.str(self.type())),
+                          u"pixie.stdlib/InvalidFieldException")
 
         old_val = self._fields[idx]
         if isinstance(old_val, AbstractMutableCell):
@@ -71,7 +72,8 @@ class CustomTypeInstance(Object):
     def get_field(self, name):
         idx = self._custom_type.get_slot_idx(name)
         if idx == -1:
-            runtime_error(u"Invalid field named " + rt.name(rt.str(name)) + u" on type " + rt.name(rt.str(self.type())))
+            runtime_error(u"Invalid field named " + rt.name(rt.str(name)) + u" on type " + rt.name(rt.str(self.type())),
+                          u"pixie.stdlib/InvalidFieldException")
 
         if self._custom_type.is_mutable(name):
             value = self._fields[idx]

--- a/pixie/vm/interpreter.py
+++ b/pixie/vm/interpreter.py
@@ -81,7 +81,8 @@ class Frame(object):
         self.sp -= 1
 
         if not 0 <= self.sp < len(self.stack):
-            runtime_error(u"Stack out of range: " + unicode(str(self.sp)))
+            runtime_error(u"Stack out of range: " + unicode(str(self.sp)),
+                          u"pixie.vm.interpreter/InterpreterError")
 
         v = self.stack[self.sp]
         self.stack[self.sp] = None
@@ -91,7 +92,8 @@ class Frame(object):
     def nth(self, delta):
         affirm(delta >= 0, u"Invalid nth value, (compiler error)")
         if not self.sp - 1 >= delta:
-            runtime_error(u"Interpreter nth out of range: " + unicode(str(self.sp - 1)) + u", " + unicode(str(delta)))
+            runtime_error(u"Interpreter nth out of range: " + unicode(str(self.sp - 1)) + u", " + unicode(str(delta)),
+                          u"pixie.vm.interpreter/InterpreterError")
         return self.stack[self.sp - delta - 1]
 
     def push_nth(self, delta):

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -68,7 +68,8 @@ class ExternalLib(object.Object):
                     self._dyn_lib = dynload.dlopen(s)
                     self._is_inited = True
                 except dynload.DLOpenError as ex:
-                    raise object.WrappedException(object.RuntimeException(rt.wrap(u"Couldn't Load Library: " + self._name)))
+                    raise object.runtime_error(u"Couldn't Load Library: " + self._name,
+                                               u"pixie.stdlib/LibraryNotFoundException")
                 finally:
                     rffi.free_charp(s)
 

--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -114,7 +114,10 @@ def istypeinstance(obj, t):
 
 class RuntimeException(Object):
     _type = Type(u"pixie.stdlib.RuntimeException")
-    def __init__(self, data):
+    def __init__(self, msg, data):
+        assert data is not None
+        assert msg is not None
+        self._msg = msg
         self._data = data
         self._trace = []
 
@@ -129,8 +132,8 @@ class RuntimeException(Object):
         for x in trace:
             s.append(x.__repr__())
             s.append(u"\n")
-
-        s.extend([u"RuntimeException: " + rt.name(rt.str(self._data)) + u"\n"])
+        s.extend([u"RuntimeException: " + rt.name(rt.str(self._data)) + u" " +
+                  rt.name(rt.str(self._msg)) + u"\n"])
 
         return u"".join(s)
 
@@ -150,11 +153,15 @@ def affirm(val, msg):
     assert isinstance(msg, unicode)
     if not val:
         import pixie.vm.rt as rt
-        raise WrappedException(RuntimeException(rt.wrap(msg)))
+        from pixie.vm.keyword import keyword
+        raise WrappedException(RuntimeException(rt.wrap(msg), keyword(u"pixie.stdlib/AssertionException")))
 
-def runtime_error(msg):
+def runtime_error(msg, data=None):
     import pixie.vm.rt as rt
-    raise WrappedException(RuntimeException(rt.wrap(msg)))
+    from pixie.vm.keyword import keyword
+    if data is None:
+        data = u"pixie.stdlib/AssertionException"
+    raise WrappedException(RuntimeException(rt.wrap(msg), keyword(data)))
 
 def safe_invoke(f, args):
     try:

--- a/pixie/vm/persistent_vector.py
+++ b/pixie/vm/persistent_vector.py
@@ -182,7 +182,8 @@ class PersistentVector(object.Object):
         if idx == self._cnt:
             return self.conj(val)
         else:
-            object.runtime_error(u"index out of range")
+            object.runtime_error(u"index out of range",
+                                 u"pixie.stdlib/OutOfRangeException")
 
 
 def do_assoc(lvl, node, idx, val):

--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -787,7 +787,7 @@ def throw_syntax_error_with_data(rdr, txt):
         meta = nil
 
     data = rt.interpreter_code_info(meta)
-    err = object.RuntimeException(rt.wrap(txt))
+    err = object.runtime_error(txt)
     err._trace.append(data)
     raise object.WrappedException(err)
 
@@ -797,7 +797,8 @@ def read_inner(rdr, error_on_eof, always_return_form=True):
         eat_whitespace(rdr)
     except EOFError as ex:
         if error_on_eof:
-            runtime_error(u"Unexpected EOF while reading")
+            runtime_error(u"Unexpected EOF while reading",
+                          u"pixie.stdlib/EOFWhileReadingException")
         return eof
 
 


### PR DESCRIPTION
Previously catch didn't allow for filtering exceptions, this can now be done. 