### PR TITLE
Exit the repl when the form is just `:exit`

### DIFF
--- a/pixie/repl.pxi
+++ b/pixie/repl.pxi
@@ -19,7 +19,7 @@
                              ""))))]
     (loop []
       (try (let [form (read rdr false)]
-             (if (= form eof)
+             (if (or (= form eof) (= form :exit))
                (exit 0)
                (let [x (eval form)]
                  (pixie.stdlib/-push-history x)


### PR DESCRIPTION
It does *not* exit when `:exit` is the result of evaluating an expression, e.g. `(do :exit)` and `(or nil false :exit)` both don't exit, but just `:exit` does.

A similar feature was present in the old repl, but hadn't made it into the current one.