### PR TITLE
From #176 Add 2-argument reduce with function identity

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -160,8 +160,11 @@
                                    nil)))))]
                 (map (fn [args] (apply f args)) (step colls))))))
 
-(def reduce (fn [rf init col]
-              (-reduce col rf init)))
+(def reduce (fn
+             ([rf col]
+              (reduce rf (rf) col))
+             ([rf init col]
+              (-reduce col rf init))))
 
 (def instance? (fn ^{:doc "Checks if x is an instance of t.
 

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -508,3 +508,8 @@
   (t/assert-throws? RuntimeException
     "proto must be a Protocol"
     (satisfies? [IIndexed :also-not-a-proto] [1 2])))
+
+(t/deftest test-reduce
+ (t/assert= 5050 (reduce + (range 101)))
+ (t/assert= 3628800 (reduce * (range 1 11)))
+ (t/assert= 5051 (reduce + 1 (range 101))))


### PR DESCRIPTION
Added the reduce arity from #176 suggested by @heyLu, using the identity of a function.

Diverges from Clojure's behavior.