### PR TITLE
Make comp work when the number of arguments is divisible by 4.

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -767,6 +767,7 @@ there's a value associated with the key. Use `some` for checking for values."
    :examples [["((comp inc first) [41 2 3])" nil 42]]
    :signatures [[f] [f & fs]]
    :added "0.1"}
+  ([] identity)
   ([f] f)
   ([f1 f2]
      (fn [& args]

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -530,3 +530,7 @@
  (t/assert= 5050 (reduce + (range 101)))
  (t/assert= 3628800 (reduce * (range 1 11)))
  (t/assert= 5051 (reduce + 1 (range 101))))
+
+(t/deftest test-comp
+  (t/assert= 5 ((comp inc inc inc inc) 1))
+  (t/assert= :xyz ((comp) :xyz)))


### PR DESCRIPTION
Also add some tests.