### PR TITLE
Compile time checks

### DIFF
--- a/pixie/ffi-infer.pxi
+++ b/pixie/ffi-infer.pxi
@@ -108,7 +108,7 @@ return 0;
   [{:keys [size]} _]
   (cond
    (= size 8) 'pixie.stdlib/CDouble
-   :else (assert False "unknown type")))
+   :else (assert false "unknown type")))
 
 (defmethod edn-to-ctype :void
   [_ _]

--- a/pixie/io-blocking.pxi
+++ b/pixie/io-blocking.pxi
@@ -1,7 +1,6 @@
 (ns pixie.io-blocking
   (:require [pixie.streams :as st :refer :all]))
 
-
 (def fopen (ffi-fn libc "fopen" [CCharP CCharP] CVoidP))
 (def fseek (ffi-fn libc "fseek" [CVoidP CInt CInt] CInt))
 (def ftell  (ffi-fn libc "ftell" [CVoidP] CInt))
@@ -14,6 +13,7 @@
 (def popen (ffi-fn libc "popen" [CCharP CCharP] CVoidP))
 (def pclose (ffi-fn libc "pclose" [CVoidP] CInt))
 
+(def DEFAULT-BUFFER-SIZE 1024)
 
 (deftype FileStream [fp]
   IInputStream
@@ -35,8 +35,7 @@
     (fclose fp))
   IReduce
   (-reduce [this f init]
-    (let [DEFAULT-BUFFER-SIZE 1024
-          buf (buffer DEFAULT-BUFFER-SIZE)
+    (let [buf (buffer DEFAULT-BUFFER-SIZE)
           rrf (preserving-reduced f)]
       (loop [acc init]
         (let [read-count (read this buf DEFAULT-BUFFER-SIZE)]
@@ -45,8 +44,7 @@
               (if (not (reduced? result))
                 (recur result)
                 @result))
-            acc))))
-    ))
+            acc))))))
 
 (defn open-read
   {:doc "Open a file for reading, returning a IInputStream"
@@ -139,8 +137,7 @@
     (pclose fp))
   IReduce
   (-reduce [this f init]
-    (let [DEFAULT-BUFFER-SIZE 1024
-          buf (buffer DEFAULT-BUFFER-SIZE)
+    (let [buf (buffer DEFAULT-BUFFER-SIZE)
           rrf (preserving-reduced f)]
       (loop [acc init]
         (let [read-count (read this buf DEFAULT-BUFFER-SIZE)]
@@ -149,8 +146,7 @@
               (if (not (reduced? result))
                 (recur result)
                 @result))
-            acc))))
-    ))
+            acc))))))
 
 (defn popen-read
   {:doc "Open a file for reading, returning a IInputStream"

--- a/pixie/io-blocking.pxi
+++ b/pixie/io-blocking.pxi
@@ -1,6 +1,5 @@
 (ns pixie.io-blocking
-  (:require [pixie.streams :as st :refer :all]
-            [pixie.io.common :as common]))
+  (:require [pixie.streams :as st :refer :all]))
 
 
 (def fopen (ffi-fn libc "fopen" [CCharP CCharP] CVoidP))
@@ -36,7 +35,18 @@
     (fclose fp))
   IReduce
   (-reduce [this f init]
-    (common/stream-reducer this f init)))
+    (let [DEFAULT-BUFFER-SIZE 1024
+          buf (buffer DEFAULT-BUFFER-SIZE)
+          rrf (preserving-reduced f)]
+      (loop [acc init]
+        (let [read-count (read this buf DEFAULT-BUFFER-SIZE)]
+          (if (> read-count 0)
+            (let [result (reduce rrf acc buf)]
+              (if (not (reduced? result))
+                (recur result)
+                @result))
+            acc))))
+    ))
 
 (defn open-read
   {:doc "Open a file for reading, returning a IInputStream"
@@ -129,7 +139,18 @@
     (pclose fp))
   IReduce
   (-reduce [this f init]
-    (common/stream-reducer this f init)))
+    (let [DEFAULT-BUFFER-SIZE 1024
+          buf (buffer DEFAULT-BUFFER-SIZE)
+          rrf (preserving-reduced f)]
+      (loop [acc init]
+        (let [read-count (read this buf DEFAULT-BUFFER-SIZE)]
+          (if (> read-count 0)
+            (let [result (reduce rrf acc buf)]
+              (if (not (reduced? result))
+                (recur result)
+                @result))
+            acc))))
+    ))
 
 (defn popen-read
   {:doc "Open a file for reading, returning a IInputStream"

--- a/pixie/io/tty.pxi
+++ b/pixie/io/tty.pxi
@@ -11,8 +11,8 @@
     (common/cb-stream-reader uv-client buf len))
   IDisposable
   (-dispose! [this]
-    (dispose! uvbuf)
-    (fs_close fp))
+    (dispose! uv-write-buf)
+    (uv/uv_close uv-client st/close_cb))
   IReduce
   (-reduce [this f init]
     (common/stream-reducer this f init)))

--- a/pixie/stacklets.pxi
+++ b/pixie/stacklets.pxi
@@ -39,6 +39,9 @@
       (throw (:ex val))
       val)))
 
+(def close_cb (ffi/ffi-prep-callback uv/uv_close_cb
+                                 pixie.ffi/dispose!))
+
 (defn -run-later [f]
   (let [a (uv/uv_async_t)
         cb (atom nil)]
@@ -56,13 +59,9 @@
       (-release-lock main-loop-lock))
     nil))
 
-
 (defn yield-control []
   (call-cc (fn [k]
              (-run-later (partial run-and-process k)))))
-
-(def close_cb (ffi/ffi-prep-callback uv/uv_close_cb
-                                 pixie.ffi/dispose!))
 
 ;;; Sleep
 (defn sleep [ms]

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1267,6 +1267,7 @@ and implements IAssociative, ILookup and IObject."
   (let [ctor-name (symbol (str "->" (name nm)))
         map-ctor-name (symbol (str "map" (name ctor-name)))
         fields (transduce (map (comp keyword name)) conj fields)
+        constructor-decl `(def ~ctor-name)
         type-from-map `(defn ~map-ctor-name [m]
                          (apply ~ctor-name (map #(get m %) ~fields)))
         default-bodies ['IAssociative
@@ -1294,7 +1295,8 @@ and implements IAssociative, ILookup and IObject."
                         `(-hash [self]
                                 (throw [:pixie.stdlib/NotImplementedException "not implemented"]))]
         deftype-decl `(deftype ~nm ~fields ~@default-bodies ~@body)]
-    `(do ~type-from-map
+    `(do ~constructor-decl
+         ~type-from-map
          ~deftype-decl)))
 
 (defn print

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -41,6 +41,25 @@
                (cons 'loop* args)))
 (set-macro! loop)
 
+;; Unfortunately declare is defined much later and depends on a bunch of these things,
+;; so using 'def' instead.
+(def rest)
+(def every?)
+(def not)
+(def comp)
+(def hash-set)
+(def keyword?)
+(def assert)
+(def symbol?)
+(def fnil)
+(def or)
+(def take)
+(def doc-ns)
+(def destructure-vector)
+(def destructure-map)
+(def range)
+(def *e)
+(def mapv)
 (def identity
   (fn ^{:doc "The identity function. Returns its argument."
         :added "0.1"}

--- a/pixie/streams/utf8.pxi
+++ b/pixie/streams/utf8.pxi
@@ -39,7 +39,7 @@
                             (= 0xF0 (bit-and ch 0xF8)) [(bit-and ch 7) 4 false]
                             (= 0xF8 (bit-and ch 0xF8)) [(bit-and ch 3) 5 true]
                             (= 0xFC (bit-and ch 0xFE)) [(bit-and ch 1) 6 true]
-                            :else [n 1 true])]
+                            :else [ch 1 true])]
       (loop [i (dec bytes)
              n n]
         (if (pos? i)

--- a/pixie/vm/compiler.py
+++ b/pixie/vm/compiler.py
@@ -255,9 +255,6 @@ class LocalMacro(LocalType):
     def emit(self, ctx):
         compile_form(self._from, ctx)
 
-
-
-
 def resolve_var(ctx, name):
     return NS_VAR.deref().resolve(name)
 
@@ -351,7 +348,7 @@ def compile_meta(meta, ctx):
     ctx.bytecode.append(1)
     ctx.sub_sp(1)
 
-def compile_form(form, ctx):
+def compile_form(form, ctx, resolve_syms=False):
     if form is nil:
         ctx.push_const(nil)
         return
@@ -377,6 +374,7 @@ def compile_form(form, ctx):
         ns = rt.namespace(form)
 
         loc = resolve_local(ctx, name)
+
         var = resolve_var(ctx, form)
 
         if var is None and loc:
@@ -388,7 +386,6 @@ def compile_form(form, ctx):
             return
         
         if var is None:
-            name = rt.name(form)
             var = NS_VAR.deref().intern_or_make(name)
 
         ctx.push_const(var)
@@ -603,6 +600,7 @@ def compile_def(form, ctx):
 
 
     ctx.push_const(var)
+    # Check that all symbols resolve
     compile_form(val, ctx)
     ctx.bytecode.append(code.SET_VAR)
     ctx.sub_sp(1)

--- a/pixie/vm/compiler.py
+++ b/pixie/vm/compiler.py
@@ -1,4 +1,4 @@
-from pixie.vm.object import affirm 
+from pixie.vm.object import affirm, compilation_error 
 from pixie.vm.primitives import nil, true, Bool
 from pixie.vm.persistent_vector import EMPTY, PersistentVector
 from pixie.vm.persistent_hash_set import PersistentHashSet
@@ -255,6 +255,9 @@ class LocalMacro(LocalType):
     def emit(self, ctx):
         compile_form(self._from, ctx)
 
+
+
+
 def resolve_var(ctx, name):
     return NS_VAR.deref().resolve(name)
 
@@ -348,7 +351,7 @@ def compile_meta(meta, ctx):
     ctx.bytecode.append(1)
     ctx.sub_sp(1)
 
-def compile_form(form, ctx, resolve_syms=False):
+def compile_form(form, ctx):
     if form is nil:
         ctx.push_const(nil)
         return
@@ -374,7 +377,6 @@ def compile_form(form, ctx, resolve_syms=False):
         ns = rt.namespace(form)
 
         loc = resolve_local(ctx, name)
-
         var = resolve_var(ctx, form)
 
         if var is None and loc:
@@ -386,7 +388,7 @@ def compile_form(form, ctx, resolve_syms=False):
             return
         
         if var is None:
-            var = NS_VAR.deref().intern_or_make(name)
+            compilation_error(u"Could not resolve symbol: " + rt.name(rt.str(form)) + u" in this context.")
 
         ctx.push_const(var)
 
@@ -600,7 +602,6 @@ def compile_def(form, ctx):
 
 
     ctx.push_const(var)
-    # Check that all symbols resolve
     compile_form(val, ctx)
     ctx.bytecode.append(code.SET_VAR)
     ctx.sub_sp(1)

--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -137,6 +137,31 @@ class RuntimeException(Object):
 
         return u"".join(s)
 
+class CompilationError(Object):
+    _type = Type(u"pixie.stdlib.CompilationError")
+    def __init__(self, msg, data):
+        assert data is not None
+        assert msg is not None
+        self._msg = msg
+        self._data = data
+        self._trace = []
+
+    def type(self):
+        return CompilationError._type
+
+    def __repr__(self):
+        import pixie.vm.rt as rt
+        s = []
+        trace = self._trace[:]
+        trace.reverse()
+        for x in trace:
+            s.append(x.__repr__())
+            s.append(u"\n")
+        s.extend([u"CompilationError: " + rt.name(rt.str(self._data)) + u" " +
+                  rt.name(rt.str(self._msg)) + u"\n"])
+
+        return u"".join(s)
+
 class WrappedException(Exception):
     def __init__(self, ex):
         assert isinstance(ex, RuntimeException)
@@ -162,6 +187,11 @@ def runtime_error(msg, data=None):
     if data is None:
         data = u"pixie.stdlib/AssertionException"
     raise WrappedException(RuntimeException(rt.wrap(msg), keyword(data)))
+
+def compilation_error(msg):
+    import pixie.vm.rt as rt
+    from pixie.vm.keyword import keyword
+    raise WrappedException(CompilationError(rt.wrap(msg), keyword(u"pixie.stdlib/CompilationError")))
 
 def safe_invoke(f, args):
     try:

--- a/tests/pixie/tests/test-compiler.pxi
+++ b/tests/pixie/tests/test-compiler.pxi
@@ -35,3 +35,6 @@
 
 (t/deftest test-deftype-mutables
   (mutate! (->Foo 0)))
+
+(t/deftest test-unresolved-symbols
+  (t/assert-throws? (eval (read-string "(defn foo [x] i-dont-exist))"))))

--- a/tests/pixie/tests/test-compiler.pxi
+++ b/tests/pixie/tests/test-compiler.pxi
@@ -37,4 +37,4 @@
   (mutate! (->Foo 0)))
 
 (t/deftest test-unresolved-symbols
-  (t/assert-throws? (eval (read-string "(defn foo [x] i-dont-exist))"))))
+  (t/assert-throws? (eval (read-string "(defn foo [x] i-dont-exist)"))))


### PR DESCRIPTION
This is a bit of a big pull request and touches lots of files. It does pick up on a bunch of typos and possible bugs though and will hopefully stop these mistakes in the future. 

Basically every symbol gets checked to see if it exists in the namespace and throws an error if it can't be resolved. For example previously i could write a function `(defn foo [x] not-defined)` and there would be no compilation error.