### PR TITLE
remove unused buffer for TTYInputStream

### DIFF
--- a/pixie/channels.pxi
+++ b/pixie/channels.pxi
@@ -23,7 +23,7 @@
     (cond
      (= idx 0) val
      (= idx 1) cfn
-     :else (throw "Index out of range")))
+     :else (throw [::OutOfRangeException "Index out of range"])))
   (-nth-not-found [this idx not-found]
     (cond
      (= idx 0) val

--- a/pixie/io.pxi
+++ b/pixie/io.pxi
@@ -79,7 +79,7 @@
             _ (pixie.ffi/set! uvbuf :len (- (count buffer) buffer-offset))
             write-count (fs_write fp uvbuf 1 offset)]
         (when (neg? write-count)
-          (throw (uv/uv_err_name read-count)))
+          (throw [::FileOutputStreamException (uv/uv_err_name read-count)]))
         (set-field! this :offset (+ offset write-count))
         (if (< (+ buffer-offset write-count) (count buffer))
           (recur (+ buffer-offset write-count))
@@ -136,7 +136,7 @@
 
 (defn throw-on-error [result]
   (when (neg? result)
-    (throw (uv/uv_err_name result)))
+    (throw [::UVException (uv/uv_err_name result)]))
   result)
 
 (defn open-write
@@ -169,7 +169,7 @@
                    utf8/utf8-output-stream-rf)
                (str content))
     
-    :else (throw "Expected a string or IOutputStream")))
+    :else (throw [::Exception "Expected a string or IOutputStream"])))
 
 (defn slurp 
   "Reads in the contents of input. Input must be a filename or an IInputStream"
@@ -177,7 +177,7 @@
   (let [stream (cond
                  (string? input) (open-read input)
                  (satisfies? IInputStream input) input
-                 :else (throw "Expected a string or an IInputStream"))
+                 :else (throw [:pixie.io/Exception "Expected a string or an IInputStream"]))
         result (transduce
                  (map char)
                  string-builder

--- a/pixie/io/tty.pxi
+++ b/pixie/io/tty.pxi
@@ -5,14 +5,13 @@
             [pixie.io.common :as common]
             [pixie.system :as sys]))
 
-(deftype TTYInputStream [uv-client uv-write-buf]
+(deftype TTYInputStream [uv-client]
   IInputStream
   (read [this buf len]
     (common/cb-stream-reader uv-client buf len))
   IDisposable
   (-dispose! [this]
-    (dispose! uvbuf)
-    (fs_close fp))
+    (uv/uv_close uv-client st/close_cb))
   IReduce
   (-reduce [this f init]
     (common/stream-reducer this f init)))
@@ -35,10 +34,9 @@
 
 (defn tty-input-stream [fd]
   ;(assert (= uv/UV_TTY (uv/uv_guess_handle fd)) "fd is not a TTY")
-  (let [buf (uv/uv_buf_t)
-        tty (uv/uv_tty_t)]
+  (let [tty (uv/uv_tty_t)]
     (uv/uv_tty_init (uv/uv_default_loop) tty fd 0)
-    (->TTYInputStream tty buf)))
+    (->TTYInputStream tty)))
 
 (def stdin  (tty-input-stream  sys/stdin))
 (def stdout (tty-output-stream sys/stdout))

--- a/pixie/stacklets.pxi
+++ b/pixie/stacklets.pxi
@@ -36,7 +36,7 @@
     (reset! stacklet-loop-h h)
     (-set-current-var-frames nil frames)
     (if (instance? ThrowException val)
-      (throw (:ex val))
+      (throw [::Exception (:ex val)])
       val)))
 
 (defn -run-later [f]

--- a/pixie/uv.pxi
+++ b/pixie/uv.pxi
@@ -231,7 +231,7 @@
 
 (defn throw-on-error [result]
   (if (neg? result)
-    (throw (str "UV Error: " (uv_err_name result)))
+    (throw [::UVException (str "UV Error: " (uv_err_name result))])
     result))
 
 (defmacro defuvfsfn

--- a/tests/pixie/tests/test-io.pxi
+++ b/tests/pixie/tests/test-io.pxi
@@ -38,4 +38,6 @@
 (t/deftest test-slurp-spit
   (let [val (vec (range 1280))]
     (io/spit "test.tmp" val)
-    (t/assert= val (read-string (io/slurp "test.tmp")))))
+    (t/assert= val (read-string (io/slurp "test.tmp"))))
+  (t/assert-throws? (io/slurp 1))
+  (t/assert-throws? (io/slurp :foo)))


### PR DESCRIPTION
Also migrates a bunch of `throw` statements to the new vector form.