### PR TITLE
Removed circular dependency

### DIFF
--- a/pixie/io-blocking.pxi
+++ b/pixie/io-blocking.pxi
@@ -2,7 +2,6 @@
   (:require [pixie.streams :as st :refer :all]
             [pixie.io.common :as common]))
 
-
 (def fopen (ffi-fn libc "fopen" [CCharP CCharP] CVoidP))
 (def fseek (ffi-fn libc "fseek" [CVoidP CInt CInt] CInt))
 (def ftell  (ffi-fn libc "ftell" [CVoidP] CInt))
@@ -14,7 +13,6 @@
 (def fclose (ffi-fn libc "fclose" [CVoidP] CInt))
 (def popen (ffi-fn libc "popen" [CCharP CCharP] CVoidP))
 (def pclose (ffi-fn libc "pclose" [CVoidP] CInt))
-
 
 (deftype FileStream [fp]
   IInputStream

--- a/pixie/io/common.pxi
+++ b/pixie/io/common.pxi
@@ -1,9 +1,6 @@
 (ns pixie.io.common
   "Common functionality for handling IO"
-  (:require [pixie.streams :refer :all]
-            [pixie.uv :as uv]
-            [pixie.stacklets :as st]
-            [pixie.ffi :as ffi]))
+  (:require [pixie.streams :refer :all]))
 
 (def DEFAULT-BUFFER-SIZE 1024)
 
@@ -18,44 +15,3 @@
               (recur result)
               @result))
           acc)))))
-
-(defn cb-stream-reader [uv-client buffer len]
-  (assert (<= (buffer-capacity buffer) len)
-          "Not enough capacity in the buffer")
-  (let [alloc-cb (uv/-prep-uv-buffer-fn buffer len)
-        read-cb (atom nil)]
-    (st/call-cc (fn [k]
-                  (reset! read-cb (ffi/ffi-prep-callback
-                                    uv/uv_read_cb
-                                    (fn [stream nread uv-buf]
-                                      (set-buffer-count! buffer nread)
-                                      (try
-                                        (dispose! alloc-cb)
-                                        (dispose! @read-cb)
-                                        ;(dispose! uv-buf)
-                                        (uv/uv_read_stop stream)
-                                        (st/run-and-process k (or
-                                                                (st/exception-on-uv-error nread)
-                                                                nread))
-                                        (catch ex
-                                          (println ex))))))
-                  (uv/uv_read_start uv-client alloc-cb @read-cb)))))
-
-(defn cb-stream-writer 
-  [uv-client uv-write-buf buffer]
-  (let [write-cb (atom nil)
-          uv_write (uv/uv_write_t)]
-      (ffi/set! uv-write-buf :base buffer)
-      (ffi/set! uv-write-buf :len (count buffer))
-      (st/call-cc
-       (fn [k]
-         (reset! write-cb (ffi/ffi-prep-callback
-                          uv/uv_write_cb
-                          (fn [req status]
-                            (try
-                              (dispose! @write-cb)
-                              ;(uv/uv_close uv_write st/close_cb)
-                              (st/run-and-process k status)
-                              (catch ex
-                                  (println ex))))))
-         (uv/uv_write uv_write uv-client uv-write-buf 1 @write-cb)))))

--- a/pixie/io/tcp.pxi
+++ b/pixie/io/tcp.pxi
@@ -3,6 +3,7 @@
             [pixie.streams :refer [IInputStream read IOutputStream write]]
             [pixie.io.common :as common]
             [pixie.uv :as uv]
+            [pixie.io.uv-common :as uv-common]
             [pixie.ffi :as ffi]))
 
 (defrecord TCPServer [ip port on-connect uv-server bind-addr on-connection-cb]
@@ -15,10 +16,10 @@
 (deftype TCPStream [uv-client uv-write-buf]
   IInputStream
   (read [this buffer len]
-    (common/cb-stream-reader uv-client buffer len))
+    (uv-common/cb-stream-reader uv-client buffer len))
   IOutputStream
   (write [this buffer]
-    (common/cb-stream-writer uv-client uv-write-buf buffer))
+    (uv-common/cb-stream-writer uv-client uv-write-buf buffer))
   IDisposable
   (-dispose! [this]
     (dispose! uv-write-buf)

--- a/pixie/io/tty.pxi
+++ b/pixie/io/tty.pxi
@@ -3,12 +3,13 @@
             [pixie.streams :refer [IInputStream read IOutputStream write]]
             [pixie.uv :as uv]
             [pixie.io.common :as common]
+            [pixie.io.uv-common :as uv-common]
             [pixie.system :as sys]))
 
 (deftype TTYInputStream [uv-client]
   IInputStream
   (read [this buf len]
-    (common/cb-stream-reader uv-client buf len))
+    (uv/cb-stream-reader uv-client buf len))
   IDisposable
   (-dispose! [this]
     (uv/uv_close uv-client st/close_cb))
@@ -19,7 +20,7 @@
 (deftype TTYOutputStream [uv-client uv-write-buf]
   IOutputStream
   (write [this buffer]
-    (common/cb-stream-writer uv-client uv-write-buf buffer))
+    (uv-common/cb-stream-writer uv-client uv-write-buf buffer))
   IDisposable
   (-dispose! [this]
     (dispose! uv-write-buf)

--- a/pixie/io/uv-common.pxi
+++ b/pixie/io/uv-common.pxi
@@ -1,0 +1,45 @@
+(ns pixie.io.uv-common
+  (:require [pixie.stacklets :as st]
+            [pixie.uv :as uv]
+            [pixie.ffi :as ffi]))
+
+(defn cb-stream-reader [uv-client buffer len]
+  (assert (<= (buffer-capacity buffer) len)
+          "Not enough capacity in the buffer")
+  (let [alloc-cb (uv/-prep-uv-buffer-fn buffer len)
+        read-cb (atom nil)]
+    (st/call-cc (fn [k]
+                  (reset! read-cb (ffi/ffi-prep-callback
+                                    uv/uv_read_cb
+                                    (fn [stream nread uv-buf]
+                                      (set-buffer-count! buffer nread)
+                                      (try
+                                        (dispose! alloc-cb)
+                                        (dispose! @read-cb)
+                                        ;(dispose! uv-buf)
+                                        (uv/uv_read_stop stream)
+                                        (st/run-and-process k (or
+                                                                (st/exception-on-uv-error nread)
+                                                                nread))
+                                        (catch ex
+                                          (println ex))))))
+                  (uv/uv_read_start uv-client alloc-cb @read-cb)))))
+
+(defn cb-stream-writer 
+  [uv-client uv-write-buf buffer]
+  (let [write-cb (atom nil)
+          uv_write (uv/uv_write_t)]
+      (ffi/set! uv-write-buf :base buffer)
+      (ffi/set! uv-write-buf :len (count buffer))
+      (st/call-cc
+       (fn [k]
+         (reset! write-cb (ffi/ffi-prep-callback
+                          uv/uv_write_cb
+                          (fn [req status]
+                            (try
+                              (dispose! @write-cb)
+                              ;(uv/uv_close uv_write st/close_cb)
+                              (st/run-and-process k status)
+                              (catch ex
+                                  (println ex))))))
+         (uv/uv_write uv_write uv-client uv-write-buf 1 @write-cb)))))


### PR DESCRIPTION
uv -> ffi-infer -> io-blocking -> io.common -> uv

This is fixed by making io.common require only pixie.stream
and move all uv related io stuff into io.uv-common. 