### PR TITLE
#319 Add a reasonable error message if boost is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,13 @@ help:
 	@echo "make fetch_externals	   - download and unpack external deps"
 
 build_with_jit: fetch_externals
-	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) --opt=jit target.py
+	@if [ ! -d /usr/local/include/boost -a ! -d /usr/include/boost ] ; then echo "Boost C++ Library not found" && false; fi && \
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) --opt=jit target.py && \
 	make compile_basics
 
 build_no_jit: fetch_externals
-	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) target.py
+	@if [ ! -d /usr/local/include/boost -a ! -d /usr/include/boost ] ; then echo "Boost C++ Library not found" && false; fi && \
+	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) target.py && \
 	make compile_basics
 
 compile_basics:

--- a/README.md
+++ b/README.md
@@ -62,15 +62,14 @@ First of all, the word "magic" is in quotes as it's partly a play on words, pixi
 
 However there are a few features of pixie that although may not be uncommon, are perhaps unexpected from a lisp.
 
-* Pixie implements its own virtual machine. It does not run on the JVM, CLR or Python VM. It implements its own bytecode, has its own GC and JIT. And it's small. Currently the interpreter, JIT, GC, and stdlib clock in at about 5.5MB once compiled down to an executable.
+* Pixie implements its own virtual machine. It does not run on the JVM, CLR or Python VM. It implements its own bytecode, has its own GC and JIT. And it's small. Currently the interpreter, JIT, GC, and stdlib clock in at about 10.3MB once compiled down to an executable.
 
 * The JIT makes some things fast. Very fast. Code like the following compiles down to a loop with 6 CPU instructions. While this may not be too impressive for any language that uses a tracing jit, it is fairly unique for a language as young as Pixie.
 
 ```clojure
 
-(comment
-  This code adds up to 10000 from 0 via calling a function that takes a variable number of arguments.
-  That function then reduces over the argument list to add up all given arguments.)
+;;  This code adds up to 10000 from 0 via calling a function that takes a variable number of arguments.
+;;  That function then reduces over the argument list to add up all given arguments.
 
 (defn add-fn [& args]
   (reduce -add 0 args))

--- a/pixie/vm/compiler.py
+++ b/pixie/vm/compiler.py
@@ -1,4 +1,4 @@
-from pixie.vm.object import affirm 
+from pixie.vm.object import affirm
 from pixie.vm.primitives import nil, true, Bool
 from pixie.vm.persistent_vector import EMPTY, PersistentVector
 from pixie.vm.persistent_hash_set import PersistentHashSet

--- a/pixie/vm/libs/pxic/reader.py
+++ b/pixie/vm/libs/pxic/reader.py
@@ -55,6 +55,15 @@ def read_tag(rdr):
 def read_raw_integer(rdr):
     return r_uint(ord(rdr.read()[0]) | (ord(rdr.read()[0]) << 8) | (ord(rdr.read()[0]) << 16) | (ord(rdr.read()[0]) << 24))
 
+def read_raw_bigint(rdr):
+    nchars = read_raw_integer(rdr)
+    n = rbigint.fromint(0)
+    for i in range(nchars):
+        a = rbigint.fromint(ord(rdr.read()[0]))
+        a = a.lshift(8*i)
+        n = n.add(a)
+    return n
+
 def read_raw_string(rdr):
     s = rdr.read_cached_string()
     return s
@@ -138,6 +147,8 @@ def read_obj(rdr):
 
     if tag == INT:
         return Integer(intmask(read_raw_integer(rdr)))
+    elif tag == BIGINT:
+        return BigInteger(read_raw_bigint(rdr))
     elif tag == CODE:
         return read_code(rdr)
     elif tag == NIL:

--- a/tests/pixie/tests/test-numbers.pxi
+++ b/tests/pixie/tests/test-numbers.pxi
@@ -70,6 +70,6 @@
 
 (t/deftest test-promotion
   (t/assert= BigInteger (type (reduce * 1 (range 1 100))))
-  (t/assert (-num-eq 1000000000000000000000N (* 10000000 
-                                                10000000 
+  (t/assert (-num-eq 1000000000000000000000N (* 10000000
+                                                10000000
                                                 10000000))))


### PR DESCRIPTION
This is a bit of a hack implementation, I know—what should really happen is that we should switch to using autoconf and automake to check dependencies and generate build targets. Essentially it just checks two common include directories: `/usr/local/include` and `/usr/include` for the boost folder, and if it isn't there, it refuses to compile and prints a message that Boost is not found. This addresses #319 

I also updated the Readme a bit—the current size of the executable is 10.3 MB, so I updated that. Also, I used `;;` for the comments rather than `(comment ...)`.