### PR TITLE
read-line handles BufferedInputStreams

### DIFF
--- a/benchmarks/read-line.pxi
+++ b/benchmarks/read-line.pxi
@@ -1,0 +1,18 @@
+(ns benchmarks.readline
+  (:require [pixie.time :as time]
+            [pixie.io :as io]))
+
+(def file-name "/usr/share/dict/words")
+
+(println "testing unbuffered")
+(time/time (-> file-name
+               (io/open-read)
+               (io/line-seq)
+               (count)))
+
+(println "testing buffered")
+(time/time (-> file-name
+               (io/open-read)
+               (io/buffered-input-stream)
+               (io/line-seq)
+               (count)))

--- a/pixie/io.pxi
+++ b/pixie/io.pxi
@@ -88,7 +88,7 @@
     (unbuffered-read-line input-stream)
     
     :else
-    (throw [::Exception "Expected an IInputStream or IByteInputStream"])))
+    (throw [::Exception "Expected an IInputStream or BufferedInputStream"])))
 
 (defn line-seq
   "Returns the lines of text from input-stream as a lazy sequence of strings.

--- a/pixie/string.pxi
+++ b/pixie/string.pxi
@@ -75,14 +75,8 @@
   "True if s is nil, empty, or contains only whitespace."
   [s]
   (if s
-    (let [white (set whitespace)
-          length (count s)]
-      (loop [index 0]
-        (if (= length index)
-          true
-          (if (white (nth s index))
-            (recur (inc index))
-            false))))
+    (let [white (set whitespace)]
+      (every? white s))
     true))
 
 (defn escape

--- a/pixie/vm/cons.py
+++ b/pixie/vm/cons.py
@@ -57,12 +57,5 @@ def _with_meta(self, meta):
 def cons(head, tail):
     return Cons(head, tail)
 
-def count(self):
-        cnt = 0
-        while self is not nil:
-            self = self.next()
-            cnt += 1
-        return cnt
-
 def cons(head, tail=nil):
     return Cons(head, tail, nil)

--- a/pixie/vm/keyword.py
+++ b/pixie/vm/keyword.py
@@ -77,5 +77,5 @@ def _hash(self):
 def _keyword(s):
     if not isinstance(s, String):
         from pixie.vm.object import runtime_error
-        runtime_error(u"Symbol name must be a string")
+        runtime_error(u"Keyword name must be a string")
     return keyword(s._str)

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from pixie.vm.object import Type, _type_registry, WrappedException, RuntimeException, affirm, InterpreterCodeInfo, istypeinstance, \
     runtime_error, add_info, ExtraCodeInfo
-from pixie.vm.code import BaseCode, PolymorphicFn, wrap_fn, as_var, defprotocol, extend, Protocol, Var, \
-                          list_copy, returns, intern_var
+from pixie.vm.code import Namespace, BaseCode, PolymorphicFn, wrap_fn, as_var, defprotocol, extend, Protocol, Var, \
+                          list_copy, returns, intern_var, _ns_registry
 import pixie.vm.code as code
 from pixie.vm.primitives import true, false, nil
 import pixie.vm.numbers as numbers
 import rpython.rlib.jit as jit
 from rpython.rlib.rarithmetic import r_uint
 from rpython.rlib.objectmodel import we_are_translated
+import os.path as path
+import sys
 
 defprotocol("pixie.stdlib", "ISeq", ["-first", "-next"])
 defprotocol("pixie.stdlib", "ISeqable", ["-seq"])
@@ -351,7 +353,6 @@ def is_undefined(var):
 def load_ns(filename):
     import pixie.vm.string as string
     import pixie.vm.symbol as symbol
-    import os.path as path
 
     if isinstance(filename, symbol.Symbol):
         affirm(rt.namespace(filename) is None, u"load-file takes a un-namespaced symbol")
@@ -397,7 +398,6 @@ def _load_file(filename, compile=False):
     from pixie.vm.util import unicode_from_utf8
     import pixie.vm.reader as reader
     import pixie.vm.libs.pxic.writer as pxic_writer
-    import os.path as path
 
 
     affirm(isinstance(filename, String), u"filename must be a string")
@@ -439,7 +439,6 @@ def load_pxic_file(filename):
     from pixie.vm.libs.pxic.reader import Reader, read_obj
     from pixie.vm.reader import eof
     import pixie.vm.compiler as compiler
-    import sys
 
     if not we_are_translated():
         print "Loading precompiled file while interpreted, this may take time"
@@ -463,7 +462,6 @@ def load_pxic_file(filename):
 def load_reader(rdr):
     import pixie.vm.reader as reader
     import pixie.vm.compiler as compiler
-    import sys
 
     if not we_are_translated():
         print "Loading file while interpreted, this may take time"
@@ -531,7 +529,6 @@ def in_ns(ns_name):
 
 @as_var("ns-map")
 def ns_map(ns):
-    from pixie.vm.code import Namespace
     from pixie.vm.symbol import Symbol
     affirm(isinstance(ns, Namespace) or isinstance(ns, Symbol), u"ns must be a symbol or a namespace")
 
@@ -551,7 +548,6 @@ def ns_map(ns):
 
 @as_var("ns-aliases")
 def ns_aliases(ns):
-    from pixie.vm.code import Namespace
     from pixie.vm.symbol import Symbol
     affirm(isinstance(ns, Namespace) or isinstance(ns, Symbol), u"ns must be a symbol or a namespace")
 
@@ -573,7 +569,6 @@ def ns_aliases(ns):
 def refer(ns, refer, alias):
     from pixie.vm.symbol import Symbol
     from pixie.vm.string import String
-    from pixie.vm.code import _ns_registry
 
     if isinstance(ns, Symbol) or isinstance(ns, String):
         ns = _ns_registry.find_or_make(rt.name(ns))
@@ -594,9 +589,9 @@ def refer(ns, refer, alias):
 def refer_symbol(ns, sym, var):
     from pixie.vm.symbol import Symbol
 
-    affirm(isinstance(ns, code.Namespace), u"First argument must be a namespace")
+    affirm(isinstance(ns, Namespace), u"First argument must be a namespace")
     affirm(isinstance(sym, Symbol) and rt.namespace(sym) is None, u"Second argument must be a non-namespaced symbol")
-    affirm(isinstance(var, code.Var), u"Third argument must be a var")
+    affirm(isinstance(var, Var), u"Third argument must be a var")
 
     ns.add_refer_symbol(sym, var)
     return nil
@@ -712,7 +707,7 @@ def _throw(ex):
 
 @as_var("resolve-in")
 def _var(ns, nm):
-    affirm(isinstance(ns, code.Namespace), u"First argument to resolve-in must be a namespace")
+    affirm(isinstance(ns, Namespace), u"First argument to resolve-in must be a namespace")
     var = ns.resolve(nm)
     return var if var is not None else nil
 

--- a/tests/pixie/tests/test-io.pxi
+++ b/tests/pixie/tests/test-io.pxi
@@ -60,6 +60,10 @@
     (t/assert= (char (io/read-byte f)) \i)
     (t/assert= (char (io/read-byte f)) \s)))
 
+(t/deftest test-buffered-input-streams-throws-on-non-input-streams
+  (let [f (io/buffered-input-stream (io/open-read "tests/pixie/tests/test-io.txt"))]
+    (t/assert-throws? (io/buffered-input-stream f))))
+
 (t/deftest test-buffered-input-streams-seek
   ;; We use a buffer size of 4 because the test file isn't huge and i am terrible at
   ;; counting characters...

--- a/tests/pixie/tests/test-keywords.pxi
+++ b/tests/pixie/tests/test-keywords.pxi
@@ -30,4 +30,9 @@
 
 (t/deftest string-to-keyword
   (t/assert= (keyword "foo") :foo)
-  (t/assert= (keyword "foo/bar") :foo/bar))
+  (t/assert= (keyword "foo/bar") :foo/bar)
+  (t/assert-throws? (keyword 1))
+  (t/assert-throws? (keyword :a))
+  (t/assert-throws? (keyword 'a))
+  (t/assert-throws? (keyword nil))
+  (t/assert-throws? (keyword true)))

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -544,6 +544,13 @@
     "c must be a type"
     (instance? [Keyword :also-not-a-type] 123)))
 
+(t/deftest test-types-are-types
+  (t/assert= Type (type Keyword))
+  (t/assert= Type (type Integer))
+  (t/assert= Type (type Number))
+  (t/assert= Type (type Object))
+  (t/assert= Type (type Type)))
+
 (t/deftest test-satisfies?
   (t/assert= (satisfies? IIndexed [1 2]) true)
   (t/assert= (satisfies? IIndexed '(1 2)) false)


### PR DESCRIPTION
The included benchmark suggests a ~10x speed up over InputStreams.

Also deletes a few no longer relevant bits and adds a few new tests.