### PR TITLE
improve the speed of repeated get-field calls to same custom type

### DIFF
--- a/pixie/vm/custom_types.py
+++ b/pixie/vm/custom_types.py
@@ -8,7 +8,7 @@ import pixie.vm.rt as rt
 MAX_FIELDS = 32
 
 class CustomType(Type):
-    _immutable_fields_ = ["_slots", "_rev?"]
+    _immutable_fields_ = ["_slots[*]", "_rev?"]
     def __init__(self, name, slots):
         Type.__init__(self, name)
 
@@ -16,7 +16,7 @@ class CustomType(Type):
         self._mutable_slots = {}
         self._rev = 0
 
-    @jit.elidable_promote()
+    @jit.elidable
     def get_slot_idx(self, nm):
         return self._slots.get(nm, -1)
 
@@ -26,19 +26,19 @@ class CustomType(Type):
             self._mutable_slots[nm] = nm
 
 
-    @jit.elidable_promote()
+    @jit.elidable
     def _is_mutable(self, nm, rev):
         return nm in self._mutable_slots
 
     def is_mutable(self, nm):
         return self._is_mutable(nm, self._rev)
 
-    @jit.elidable_promote()
+    @jit.elidable
     def get_num_slots(self):
         return len(self._slots)
 
 class CustomTypeInstance(Object):
-    _immutable_fields_ = ["_type"]
+    _immutable_fields_ = ["_custom_type"]
     def __init__(self, type):
         affirm(isinstance(type, CustomType), u"Can't create a instance of a non custom type")
         self._custom_type = type
@@ -60,7 +60,7 @@ class CustomTypeInstance(Object):
             self.set_field_by_idx(idx, val)
         return self
 
-    @jit.elidable_promote()
+    @jit.elidable
     def _get_field_immutable(self, idx, rev):
         return self.get_field_by_idx(idx)
 


### PR DESCRIPTION
Hey, this is my first PR so I'm obviously open to feedback. :)

Background: I was trying to write my own "take" and "repeat" for a project I'm working on, because the ones in stdlib give stack overflows for large n:

```
=> (repeat 5000 'x)
ERROR: 
 RuntimeException: :pixie.stdlib/InternalError Internal error: <StackOverflow object at 0xc027d8>
```

Here's a basic first try, not perfect but it illustrates the problem:

```
(deftype Repeater [n x]
  ISeq
  (-first [_] (when (seq _) x))
  (-next [_] (when (seq _)
               (->Repeater (dec n) x)))
  ISeqable
  (-seq [_] (if (zero? n) nil _)))
```

Unfortunately it's unacceptably slow:
```
 => (load-ns 'pixie.time)
nil
 => (pixie.time/time (count (->Repeater 1000000 'x)))
"Elapsed time: 8942.358402 ms"
1000000
```

Initially I thought it was the object creation that was slow, but it's not; it's the implicit get-field calls. Creating a million repeaters is quick:

```
  => (pixie.time/time (dotimes (_ 1000000) (next (->Repeater 1 'x))))
"Elapsed time: 9041.095552 ms"
nil
 => (pixie.time/time (dotimes (_ 1000000) (->Repeater 1 'x)))
"Elapsed time: 12.137923 ms"
nil
```

If the same _identical_ object were used again and again, the JIT would make the get-field calls to that ONE object very fast, but with one million different objects of the same type, the JIT can't figure it out. It's the same with stdlib deftypes such as Range. Taking the "first" of a million different ranges is slow (though you'd probably never do that). 

I believe this is due to using @jit.elidable_promote() which seems to promote "self" when it should not -- changing to @elidable seemed to solve the problem. I also fixed up the declared `_immutable_fields_` (if I understand the rules correctly), though I don't think that had any effect.

After changing to @elidable:

```
 => (pixie.time/time (count (->Repeater 1000000 'x)))
"Elapsed time: 67.877114 ms"
1000000

