### PR TITLE
Add sort support from @thomasmulvaney

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2584,3 +2584,37 @@ Calling this function on something that is not ISeqable returns a seq with that 
   (if (satisfies? IComparable x)
     (-compare x y)
     (throw [::ComparisonError (str x " does not satisfy IComparable")])))
+
+;;; Sorting
+
+(defn -merge-sort-step
+  [comp-fn merged-left merged-right res]
+  (cond 
+    (empty? merged-left) (into res merged-right) 
+    (empty? merged-right) (into res merged-left) 
+    :else
+    (if (neg? (comp-fn (first merged-left) (first merged-right)))
+      (recur comp-fn (rest merged-left) merged-right (conj res (first merged-left)))
+      (recur comp-fn merged-left (rest merged-right) (conj res (first merged-right))))))
+
+(defn -merge-sort-split
+  [comp-fn coll]
+  (if (> (count coll) 1)
+    (let [[left right] (split-at (/ (count coll) 2) coll)]
+      (-merge-sort-step comp-fn 
+                        (-merge-sort-split comp-fn left) 
+                        (-merge-sort-split comp-fn right) 
+                        [])) 
+    coll))
+
+(defn merge-sort [comp-fn coll]
+  (-merge-sort-split comp-fn coll))
+
+(defn sort 
+  ([coll]
+   (sort compare coll))
+  ([comp-fn coll]
+   (merge-sort comp-fn coll)))
+
+
+;;; End Sorting

--- a/pixie/test-sort.pxi
+++ b/pixie/test-sort.pxi
@@ -1,0 +1,11 @@
+(ns pixie.tests.test-sort
+  (require pixie.test :as t))
+
+(t/deftest test-sort
+  (t/assert= (sort [5 2 3 1 4]) [1 2 3 4 5])
+  (t/assert= (sort ["d" "c" "b" "a"]) ["a" "b" "c" "d"])
+  (t/assert= (sort [1/1 1/2 1/3 1/4]) [1/4 1/3 1/2 1/1]))
+
+(t/deftest test-sort-big
+  (t/assert= (sort (range 10000))      (range 10000))
+  (t/assert= (sort (range 9999 -1 -1)) (range 10000)))


### PR DESCRIPTION
Re-adds @thomasmulvaney's merge-sort. It's not a bad algorithm, although the JIT will probably throw a fit with it. We should improve it in the future to a) use mutable arrays during sorting and b) investigate how to get the JIT to be happier. Perhaps we should re-write it in RPython to get C-like speeds and call into Pixie for the comparisons. At any rate, we need some sort of sort at this point. So let's work with this. 
