### PR TITLE
fixed (count (lazy-seq [])) incorrectly returning 1

### DIFF
--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -258,9 +258,12 @@ def count(x):
     while True:
         _count_driver.jit_merge_point(tp=rt.type(x))
         if ICounted.satisfies(rt.type(x)):
-           return rt._add(rt.wrap(acc), rt._count(x))
+            return rt._add(rt.wrap(acc), rt._count(x))
+        seq = rt.seq(x)
+        if seq is nil:
+            return rt.wrap(acc)
         acc += 1
-        x = rt.next(rt.seq(x))
+        x = rt._next(seq)
 
 
 @as_var("+")

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -218,6 +218,28 @@
   (t/assert= (empty {:a 1, :b 2, :c 3}) {})
   (t/assert= (empty #{1 2 3}) #{}))
 
+(t/deftest test-count
+  (t/assert= (count nil) 0)
+  (t/assert= (count '()) 0)
+  (t/assert= (count '(1 2 '(3 4))) 3)
+  (t/assert= (count '(nil nil nil)) 3)
+  (t/assert= (count (cons 1 [2 3])) 3)
+  (t/assert= (count (list)) 0)
+  (t/assert= (count (list 1 2 3)) 3)
+  (t/assert= (count []) 0)
+  (t/assert= (count [1 2 3]) 3)
+  (t/assert= (count {}) 0)
+  (t/assert= (count {:a 1, :b 2, :c 3}) 3)
+  (t/assert= (count (first (seq {:a 1, :b 2, :c 3}))) 2)
+  (t/assert= (count #{}) 0)
+  (t/assert= (count (conj #{1 2 3} 3)) 3)
+  (t/assert= (count (lazy-seq '())) 0)
+  (t/assert= (count (lazy-seq '(1 2 3))) 3)
+  (t/assert= (count (cons 1 (lazy-seq [2 3]))) 3)
+  (t/assert= (count (range 0 -9 -3)) 3)
+  (t/assert= (count "") 0)
+  (t/assert= (count "123") 3)
+  (t/assert= (count (make-array 3)) 3))
 
 (t/deftest test-vec
   (let [v '(1 2 3 4 5)]


### PR DESCRIPTION
stdlib.py's count was incrementing acc before checking if the current object is empty. It assumed that all empty collections satisfy ICounted, but lazy-seq does not.

Also I added some tests for count.