### PR TITLE
Line reader

### DIFF
--- a/benchmarks/read-line.pxi
+++ b/benchmarks/read-line.pxi
@@ -6,17 +6,37 @@
 (def file-name "/usr/share/dict/words")
 
 (println "Lazy line-seq")
-(time/time (-> file-name
-               (io/open-read)
-               (io/line-seq)
-               (count)
-               (println)))
+(time/time 
+  (->> file-name
+       (io/open-read)
+       (io/buffered-input-stream)
+       (io/line-seq)
+       (count)))
 
 (println "Reducing line-reader")
 (time/time 
-  (-> file-name
-      (io/open-read)
-      (io/line-reader)
-      (into [])
-      (count)
-      (println)))
+  (->> file-name
+       (io/open-read)
+       (io/buffered-input-stream)
+       (io/line-reader)
+       (into [])
+       (count)))
+
+(println "Lazy UTF8 line-seq")
+(time/time 
+  (->> file-name
+       (io/open-read)
+       (io/buffered-input-stream)
+       (utf8/utf8-input-stream)
+       (io/line-seq)
+       (count)))
+
+(println "Reducing UTF8 line-reader")
+(time/time 
+  (->> file-name
+       (io/open-read)
+       (io/buffered-input-stream)
+       (utf8/utf8-input-stream)
+       (io/line-reader)
+       (into [])
+       (count)))

--- a/benchmarks/read-line.pxi
+++ b/benchmarks/read-line.pxi
@@ -1,18 +1,22 @@
 (ns benchmarks.readline
   (:require [pixie.time :as time]
-            [pixie.io :as io]))
+            [pixie.io :as io]
+            [pixie.streams.utf8 :as utf8]))
 
 (def file-name "/usr/share/dict/words")
 
-(println "testing unbuffered")
+(println "Lazy line-seq")
 (time/time (-> file-name
                (io/open-read)
                (io/line-seq)
-               (count)))
+               (count)
+               (println)))
 
-(println "testing buffered")
-(time/time (-> file-name
-               (io/open-read)
-               (io/buffered-input-stream)
-               (io/line-seq)
-               (count)))
+(println "Reducing line-reader")
+(time/time 
+  (-> file-name
+      (io/open-read)
+      (io/line-reader)
+      (into [])
+      (count)
+      (println)))

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1633,13 +1633,14 @@ The new value is thus `(apply f current-value-of-atom args)`."
   :added "0.1"}
   ([pred]
      (fn [rf]
-       (fn
-         ([] (rf))
-         ([result] (rf result))
-         ([result input]
+       (let [rrf (preserving-reduced rf)]
+         (fn
+           ([] (rf))
+           ([result] (rf result))
+           ([result input]
             (if (pred input)
-              (rf result input)
-              (reduced result))))))
+              (rrf result input)
+              (reduced result)))))))
   ([pred coll]
      (lazy-seq
       (when-let [s (seq coll)]

--- a/tests/pixie/tests/test-io.pxi
+++ b/tests/pixie/tests/test-io.pxi
@@ -33,18 +33,18 @@
       (t/assert-throws? (io/read f buf -2)))))
 
 (t/deftest test-read-line
-  (let [f (io/open-read "tests/pixie/tests/test-io.txt")]
+  (let [f (io/buffered-input-stream (io/open-read "tests/pixie/tests/test-io.txt"))]
     (io/read-line f)
     (t/assert= (io/read-line f) "Second line.")
     (t/assert= (io/read-line f) nil)))
 
 (t/deftest test-line-seq
-  (let [f (io/open-read "tests/pixie/tests/test-io.txt")
+  (let [f (io/buffered-input-stream (io/open-read "tests/pixie/tests/test-io.txt"))
         s (io/line-seq f)]
     (t/assert= (last s) "Second line.")))
 
 (t/deftest test-seek
-  (let [f (io/open-read "tests/pixie/tests/test-io.txt")]
+  (let [f (io/buffered-input-stream (io/open-read "tests/pixie/tests/test-io.txt"))]
     (io/read-line f)
     (t/assert= (io/read-line f) "Second line.")
     (io/rewind f)


### PR DESCRIPTION
This commit improves the performance of `line-seq` by introducing a reducible `LineReader`.

To keep things simple, all line operations, `line-seq`, `read-line` and `line-reader` all require either a `BufferedInputStream` or `UTF8InputStream`.

`BufferedInputStream` is now also reducible with the intention of using `(transduce (take-while #(not (line-feed? %)) string-builder reducible-stream)` instead of loops to read lines from both `UTF8InputStreams` and `BufferedInputStreams`, but the performance was terrible (~20x worse) for some reason. This is probably worth investigating some more.

`line-seq` and `-reduce` on LineReader both churn through a `BufferedInputStream` of `/usr/dict/words` in ~300ms on my machine compared to the previous ~7 seconds. The equivalent `UTF8InputStream` takes about 1 s to read now.