### PR TITLE
Map Entry equality

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -919,10 +919,14 @@ If further arguments are passed, invokes the method named by symbol, passing the
                                         (= idx 1) (-val self)
                                         :else not-found)))
 (extend -eq MapEntry (fn [self other]
-                       (and (= (-key self)
-                               (-key other))
-                            (= (-val self)
-                               (-val other)))))
+                       (cond
+                         (map-entry? other) (and (= (-key self)
+                                                    (-key other))
+                                                 (= (-val self)
+                                                    (-val other)))
+                         (vector? other) (= [(-key self) (-val self)]
+                                            other)
+                         :else (= (seq self) other))))
 
 (extend -reduce MapEntry indexed-reduce)
 
@@ -936,6 +940,10 @@ If further arguments are passed, invokes the method named by symbol, passing the
 (extend -hash MapEntry
   (fn [v]
     (transduce ordered-hash-reducing-fn v)))
+
+(extend -seq MapEntry
+  (fn [self]
+    (list (-key self) (-val self))))
 
 (defn select-keys
   {:doc "Produces a map with only the values in m contained in key-seq"}

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -871,6 +871,8 @@ If further arguments are passed, invokes the method named by symbol, passing the
 (defn indexed? [v] (satisfies? IIndexed v))
 (defn counted? [v] (satisfies? ICounted v))
 
+(defn map-entry? [v] (satisfies? IMapEntry v))
+
 (defn last
   {:doc "Returns the last element of the collection, or nil if none."
    :signatures [[coll]]
@@ -2320,7 +2322,7 @@ Expands to calls to `extend-type`."
 
 (defn float
   {:doc "Converts a number to a float."
-   :since "0.1"}  
+   :since "0.1"}
   [x]
   (-float x))
 
@@ -2348,7 +2350,7 @@ Expands to calls to `extend-type`."
 
 (defn int
   {:doc "Converts a number to an integer."
-   :since "0.1"}  
+   :since "0.1"}
   [x]
   (-int x))
 

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -675,3 +675,19 @@
 
 (t/deftest test-lazyseq-conj
   (t/assert= '(1 2 3) (conj (lazy-seq '(2 3)) 1)))
+
+(t/deftest map-entry-seq
+  (let [m (map-entry :a 1)]
+    (t/assert= (seq m) '(:a 1))
+    ;; vectors are equal to seqs if their indexed values are equal
+    ;; thus, a vector of length 2 is equal to a map-entry's seq IFoo
+    ;; their values are equal
+    (t/assert= [:a 1] m)
+    (t/assert= '(:a 1) m)))
+
+(t/deftest map-entry-equals
+  (let [m (map-entry :a 1)]
+    (t/assert= m m)
+    (t/assert= m (map-entry :a 1))
+    (t/assert= m [:a 1])
+    (t/assert= m '(:a 1))))


### PR DESCRIPTION
This extends -eq on MapEntry to include vectors (as in clojure) as well as extends -seq to MapEntry so that the reverse -eq (vector to MapEntry) can also be true.

Now the following holds,

```clj
(= (map-entry :a 1) [:a 1])
(= [:a 1] (map-entry :a 1))
```