### PR TITLE
Fix syntax quoting for maps

### DIFF
--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -430,6 +430,7 @@ APPLY = symbol(u"apply")
 CONCAT = symbol(u"concat")
 SEQ = symbol(u"seq")
 LIST = symbol(u"list")
+HASHMAP = symbol(u"hashmap")
 
 def is_unquote(form):
     return True if rt._satisfies_QMARK_(rt.ISeq.deref(), form) \
@@ -477,6 +478,9 @@ class SyntaxQuoteReader(ReaderHandler):
             return runtime_error(u"Unquote splicing not used inside list")
         elif rt.vector_QMARK_(form) is true:
             ret = rt.list(APPLY, CONCAT, SyntaxQuoteReader.expand_list(form))
+        elif rt.map_QMARK_(form) is true:
+            mes = SyntaxQuoteReader.flatten_map(form)
+            ret = rt.list(APPLY, HASHMAP, rt.list(APPLY, CONCAT, SyntaxQuoteReader.expand_list(mes)))
         elif form is not nil and rt.seq_QMARK_(form) is true:
             ret = rt.list(APPLY, LIST, rt.cons(CONCAT, SyntaxQuoteReader.expand_list(rt.seq(form))))
         else:
@@ -484,8 +488,16 @@ class SyntaxQuoteReader(ReaderHandler):
         return ret
 
     @staticmethod
+    def flatten_map(form):
+        return rt.reduce(flatten_map_rfn, EMPTY_VECTOR, form)
+
+    @staticmethod
     def expand_list(form):
         return rt.reduce(expand_list_rfn, EMPTY_VECTOR, form)
+
+@wrap_fn
+def flatten_map_rfn(ret, item):
+    return rt.conj(rt.conj(ret, rt.first(item)), rt.first(rt.next(item)))
 
 @wrap_fn
 def expand_list_rfn(ret, item):

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -667,6 +667,10 @@ def identical(a, b):
 def vector_QMARK_(a):
     return true if rt._satisfies_QMARK_(rt.IVector.deref(), a) else false
 
+@as_var("map?")
+def map_QMARK_(a):
+    return true if rt._satisfies_QMARK_(rt.IMap.deref(), a) else false
+
 @returns(bool)
 @as_var("eq")
 def eq(a, b):

--- a/tests/pixie/tests/test-macros.pxi
+++ b/tests/pixie/tests/test-macros.pxi
@@ -1,0 +1,8 @@
+(ns collections.test-macros
+  (require pixie.test :as t))
+
+(t/deftest hashmap-unquote
+  (let [x 10 k :boop]
+    (t/assert= (-eq `{:x ~x} {:x 10}) true)
+    (t/assert= (-eq `{~k ~x} {:boop 10}) true)
+    (t/assert= (-eq `{:x {:y ~x}} {:x {:y 10}}) true)))


### PR DESCRIPTION
This fixes issue #203.
I've added a test for it in `test-macros.pxi` (couldn't find any existing file to stick it in).

This also adds `map?` fn, which is similar to `vector?` etc.