### PR TITLE
Support IInputStream for line-reader

### DIFF
--- a/pixie/io.pxi
+++ b/pixie/io.pxi
@@ -87,8 +87,11 @@
     (instance? BufferedInputStream input-stream)
     (-> input-stream ->LineReader)
 
+    (satisfies? IInputStream input-stream)
+    (-> input-stream buffered-input-stream ->LineReader)
+
     :else
-    (throw [::Exception "Expected a LineReader, UTF8InputStream, or BufferedInputStream"])))
+    (throw [::Exception "Expected a LineReader, UTF8InputStream, BufferedInputStream, or IInputStream"])))
 
 (defn read-line
   "Read one line from input-stream for each invocation.

--- a/tests/pixie/tests/test-io.pxi
+++ b/tests/pixie/tests/test-io.pxi
@@ -43,6 +43,11 @@
         s (io/line-seq f)]
     (t/assert= (last s) "Second line.")))
 
+(t/deftest test-line-seq-non-buffered
+  (let [f (io/open-read "tests/pixie/tests/test-io.txt")
+        s (io/line-seq f)]
+    (t/assert= (last s) "Second line.")))
+
 (t/deftest test-seek
   (let [f (io/buffered-input-stream (io/open-read "tests/pixie/tests/test-io.txt"))]
     (io/read-line f)


### PR DESCRIPTION
Not sure if this is the best way to solve this, possibly nicer would be to just pass things into `buffered-input-stream` in the catchall and have that handle the errors.

cc @thomasmulvaney because I think he wrote a lot of the line-reader stuff