### PR TITLE
Use python2 as the default python executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: help
 
 EXTERNALS=externals
 
-PYTHON ?= python
+PYTHON ?= python2
 PYTHONPATH=$$PYTHONPATH:$(EXTERNALS)/pypy
 
 


### PR DESCRIPTION
This should make building on systems with python3 as default easier, and
also make it clear that we need python2.

Fixes #337.