### PR TITLE
Fix make clean_pxic 'rm: missing operand' error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ compile_src:
 	find * -name "*.pxi" | grep "^pixie/" | xargs -L1 ./pixie-vm $(EXTERNALS_FLAGS) -c
 
 clean_pxic:
-	find * -name "*.pxic" | xargs rm
+	find * -name "*.pxic" | xargs --no-run-if-empty rm
 
 clean: clean_pxic
 	rm -rf ./lib


### PR DESCRIPTION
`make clean_pxic` fails if no files are found due to invalid
rm command 'rm: missing operand'. Add `--no-run-if-empty` to xarg
to fix.