### PR TITLE
FFI: coerce numbers to double if required and possible

### DIFF
--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -8,7 +8,7 @@ from pixie.vm.code import as_var, affirm, extend, wrap_fn
 import pixie.vm.rt as rt
 from rpython.rtyper.lltypesystem import rffi, lltype, llmemory
 from pixie.vm.primitives import nil, true, false
-from pixie.vm.numbers import Integer, Float, BigInteger, Ratio
+from pixie.vm.numbers import to_float, Integer, Float, BigInteger, Ratio
 from pixie.vm.string import String
 from pixie.vm.keyword import Keyword
 from pixie.vm.util import unicode_to_utf8
@@ -359,12 +359,8 @@ class CDouble(CType):
         return Float(casted[0])
 
     def ffi_set_value(self, ptr, val):
-        if isinstance(val, Integer):
-            val = Float(float(val.int_val()))
-        elif isinstance(val, BigInteger):
-            val = Float(val.bigint_val().tofloat())
-        elif isinstance(val, Ratio):
-            val = Float(val.numerator() / float(val.denominator()))
+        if isinstance(val, Integer) or isinstance(val, BigInteger) or isinstance(val, Ratio):
+            val = to_float(val)
         casted = rffi.cast(rffi.DOUBLEP, ptr)
         casted[0] = rffi.cast(rffi.DOUBLE, val.float_val())
 

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -359,8 +359,7 @@ class CDouble(CType):
         return Float(casted[0])
 
     def ffi_set_value(self, ptr, val):
-        if isinstance(val, Integer) or isinstance(val, BigInteger) or isinstance(val, Ratio):
-            val = to_float(val)
+        val = to_float(val)
         casted = rffi.cast(rffi.DOUBLEP, ptr)
         casted[0] = rffi.cast(rffi.DOUBLE, val.float_val())
 

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -8,7 +8,7 @@ from pixie.vm.code import as_var, affirm, extend, wrap_fn
 import pixie.vm.rt as rt
 from rpython.rtyper.lltypesystem import rffi, lltype, llmemory
 from pixie.vm.primitives import nil, true, false
-from pixie.vm.numbers import Integer, Float
+from pixie.vm.numbers import Integer, Float, BigInteger, Ratio
 from pixie.vm.string import String
 from pixie.vm.keyword import Keyword
 from pixie.vm.util import unicode_to_utf8
@@ -359,6 +359,12 @@ class CDouble(CType):
         return Float(casted[0])
 
     def ffi_set_value(self, ptr, val):
+        if isinstance(val, Integer):
+            val = Float(float(val.int_val()))
+        elif isinstance(val, BigInteger):
+            val = Float(val.bigint_val().tofloat())
+        elif isinstance(val, Ratio):
+            val = Float(val.numerator() / float(val.denominator()))
         casted = rffi.cast(rffi.DOUBLEP, ptr)
         casted[0] = rffi.cast(rffi.DOUBLE, val.float_val())
 

--- a/pixie/vm/numbers.py
+++ b/pixie/vm/numbers.py
@@ -302,6 +302,8 @@ def to_float(x):
         return x
     if isinstance(x, Ratio):
         return rt.wrap(x.numerator() / float(x.denominator()))
+    if isinstance(x, Integer):
+        return rt.wrap(float(x.int_val()))
     if isinstance(x, BigInteger):
         return rt.wrap(x.bigint_val().tofloat())
     assert False

--- a/tests/pixie/tests/test-ffi.pxi
+++ b/tests/pixie/tests/test-ffi.pxi
@@ -58,3 +58,10 @@
 
 (t/deftest test-size
   (t/assert= (pixie.ffi/struct-size (pixie.ffi/c-struct "struct" 1234 [])) 1234))
+
+
+(t/deftest test-double-coercion
+  (t/assert= (m/sin 1) (m/sin 1.0))
+  (let [big (reduce * 1 (range 1 100))]
+    (t/assert= (m/sin big) (m/sin (float big))))
+  (t/assert= (m/sin (/ 1 2)) (m/sin (float (/ 1 2)))))


### PR DESCRIPTION
If a function invoked over FFI requires a double and a (Big)Integer or a
Ratio is supplied, automatically coerce to double.

Should help with the rest of #377.