### PR TITLE
Add coll? function

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -867,6 +867,7 @@ If further arguments are passed, invokes the method named by symbol, passing the
 (defn set? [v] (instance? PersistentHashSet v))
 (defn map? [v] (satisfies? IMap v))
 (defn fn? [v] (satisfies? IFn v))
+(defn coll? [v] (satisfies? IPersistentCollection v))
 
 (defn indexed? [v] (satisfies? IIndexed v))
 (defn counted? [v] (satisfies? ICounted v))

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -304,6 +304,16 @@
   (t/assert= (fn? "foo") false)
   (t/assert= (fn? (let [x 8] (fn [y] (+ x y)))) true))
 
+(t/deftest test-coll?
+  (t/assert= (coll? '()) true)
+  (t/assert= (coll? []) true)
+  (t/assert= (coll? {:foo "bar"}) true)
+  (t/assert= (coll? #{:foo :bar}) true)
+  (t/assert= (coll? #(%)) false)
+  (t/assert= (coll? :foo) false)
+  (t/assert= (coll? "foo") false)
+  (t/assert= (coll? 1) false))
+
 (t/deftest test-macro?
   (t/assert= (macro? and) true)
   (t/assert= (macro? or) true)


### PR DESCRIPTION
Just added the coll? function.

Some things to notice:

+  `(coll? nil)` evaluates to `true` while in Clojure it evaluates to `false`. Not sure about what the expected behaviour should be.
+ I was also not sure about whether transient collections should return `true` or `false` when being evaluated with `coll?`. This PR mimics Clojure in that, so `(coll? (transient [1]))` returns `false`.