### PR TITLE
add metadata support to records

### DIFF
--- a/tests/pixie/tests/test-defrecord.pxi
+++ b/tests/pixie/tests/test-defrecord.pxi
@@ -53,3 +53,7 @@
            (t/assert (contains? t :one))
            (t/assert (contains? t :two))
            (t/assert (contains? t :three))))
+
+(t/deftest test-record-metadata
+  (t/assert= nil (meta t1))
+  (t/assert= :foo (-> t1 (with-meta :foo) meta)))


### PR DESCRIPTION
It should be fairly safe, I just added a __meta field to the underlying deftype and then overwrite the constructor to set the metadata field to nil. 

In the process I also noticed that records do not currently permit to enumerate their keys / values via `keys` `vals`, but for now I guess it makes things more simple.