### PR TITLE
allows kw/map/set invocations with default value

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -1061,17 +1061,22 @@ If further arguments are passed, invokes the method named by symbol, passing the
 
 (extend -repr Symbol -str)
 
-(extend -invoke Keyword (fn [k m] (-val-at m k nil)))
-(extend -invoke PersistentHashMap (fn [m k] (-val-at m k nil)))
-(extend -invoke PersistentHashSet (fn [m k] (-val-at m k nil)))
-
 (defn get
   {:doc "Get an element from a collection implementing ILookup, return nil or the default value if not found."
    :added "0.1"}
   ([mp k]
      (get mp k nil))
   ([mp k not-found]
-     (-val-at mp k not-found)))
+   (-val-at mp k not-found)))
+
+(extend -invoke Keyword (fn
+                          ([k m not-found]
+                           (-val-at m k not-found))
+                          ([k m]
+                           (-val-at m k nil))))
+(extend -invoke PersistentHashMap get)
+(extend -invoke PersistentHashSet get)
+
 
 (defn get-in
   {:doc "Get a value from a nested collection at the \"path\" given by the keys."

--- a/tests/pixie/tests/collections/test-maps.pxi
+++ b/tests/pixie/tests/collections/test-maps.pxi
@@ -25,14 +25,15 @@
     (t/assert= (-eq m {:a 1, :b 2, :c 4}) false)
     (t/assert= (-eq m {:a 3, :b 2, :c 1}) false)))
 
-
 (t/deftest map-val-at-and-invoke
   (let [m {:a 1, :b 2, :c 3}]
     (foreach [e m]
              (t/assert= (get m (key e)) (val e))
              (t/assert= (m (key e)) (val e)))
     (t/assert= (get m :d) nil)
-    (t/assert= (m :d) nil)))
+    (t/assert= (m :d) nil)
+    (t/assert= (m :d :foo) :foo)
+    (t/assert= (:d m :foo) :foo)))
 
 (t/deftest map-without
   (let [m {:a 1 :b 2}]

--- a/tests/pixie/tests/collections/test-sets.pxi
+++ b/tests/pixie/tests/collections/test-sets.pxi
@@ -58,7 +58,9 @@
     (t/assert= (s 3) 3)
 
     (t/assert= (s -1) nil)
-    (t/assert= (s 4) nil)))
+    (t/assert= (s 4) nil)
+    (t/assert= (s :d :foo) :foo)
+    (t/assert= (:d s :foo) :foo)))
 
 (t/deftest test-has-meta
   (let [m {:has-meta true}

--- a/tests/pixie/tests/test-keywords.pxi
+++ b/tests/pixie/tests/test-keywords.pxi
@@ -7,7 +7,8 @@
     (t/assert= (:b m) 2)
     (t/assert= (:c m) 3)
 
-    (t/assert= (:d m) nil)))
+    (t/assert= (:d m) nil)
+    (t/assert= (:d m :foo) :foo)))
 
 (t/deftest keyword-namespace
   (t/assert= (namespace :foo/bar) "foo")


### PR DESCRIPTION
this allows default values on -val-at call with invoke such as:

```clojure
(:x {} :bar)
(:x #{} :bar)
({} :x :bar)
(#{} :x :bar) 
```