### PR TITLE
Added Unchecked Math Operations

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -510,6 +510,30 @@ returns true"
   ([x y & args]
       (reduce -mul (-mul x y) args)))
 
+(defn unchecked-add
+  {:doc "Adds the arguments, returning 0 if no arguments"
+   :signatures [[& args]]
+   :added "0.1"}
+  ([] 0)
+  ([x] x)
+  ([x y] (-unchecked-add x y))
+  ([x y & args]
+      (reduce -unchecked-add (-unchecked-add x y) args)))
+
+(defn unchecked-subtract
+  ([] 0)
+  ([x] (-unchecked-subtract 0 x))
+  ([x y] (-unchecked-subtract x y))
+  ([x y & args]
+      (reduce -unchecked-subtract (-unchecked-subtract x y) args)))
+
+(defn unchecked-multiply
+  ([] 1)
+  ([x] x)
+  ([x y] (-unchecked-multiply x y))
+  ([x y & args]
+      (reduce -unchecked-multiply (-unchecked-multiply x y) args)))
+
 (defn /
   ([x] (-div 1 x))
   ([x y] (-div x y))
@@ -609,6 +633,20 @@ returns true"
    :added "0.1"}
   [x]
   (- x 1))
+
+(defn unchecked-inc
+  {:doc "Increments x by one"
+   :signatures [[x]]
+   :added "0.1"}
+  [x]
+  (unchecked-add x 1))
+
+(defn unchecked-dec
+  {:doc "Decrements x by one"
+   :signatures [[x]]
+   :added "0.1"}
+  [x]
+  (unchecked-subtract x 1))
 
 (defn empty?
   {:doc "returns true if the collection has no items, otherwise false"

--- a/pixie/vm/numbers.py
+++ b/pixie/vm/numbers.py
@@ -107,8 +107,12 @@ _gte = as_var("-gte")(DoublePolymorphicFn(u"-gte", IMath))
 _num_eq = as_var("-num-eq")(DoublePolymorphicFn(u"-num-eq", IMath))
 _num_eq.set_default_fn(wrap_fn(lambda a, b: false))
 
-as_var("MAX-NUMBER")(Integer(100000)) # TODO: set this to a real max number
+IUncheckedMath = as_var("IUncheckedMath")(Protocol(u"IUncheckedMath"))
+_unchecked_add = as_var("-unchecked-add")(DoublePolymorphicFn(u"-unchecked-add", IUncheckedMath))
+_unchecked_subtract = as_var("-unchecked-subtract")(DoublePolymorphicFn(u"-unchecked-subtract", IUncheckedMath))
+_unchecked_multiply = as_var("-unchecked-multiply")(DoublePolymorphicFn(u"-unchecked-multiply", IUncheckedMath))
 
+as_var("MAX-NUMBER")(Integer(100000)) # TODO: set this to a real max number
 
 num_op_template = """@extend({pfn}, {ty1}._type, {ty2}._type)
 def {pfn}_{ty1}_{ty2}(a, b):
@@ -167,6 +171,16 @@ def define_num_ops():
 
 define_num_ops()
 
+def define_unchecked_num_ops():
+    # maybe define get_val() instead of using tuples?
+    num_classes = [(Integer, "int_val"), (Float, "float_val")]
+    for (c1, conv1) in num_classes:
+        for (c2, conv2) in num_classes:
+            for (op, sym) in [("_unchecked_add", "+"), ("_unchecked_subtract", "-"), ("_unchecked_multiply", "*")]:
+                extend_num_op(op, c1, c2, conv1, sym, conv2)
+
+define_unchecked_num_ops()
+                
 bigint_ops_tmpl = """@extend({pfn}, {ty1}._type, {ty2}._type)
 def _{pfn}_{ty1}_{ty2}(a, b):
     assert isinstance(a, {ty1}) and isinstance(b, {ty2})

--- a/tests/pixie/tests/test-numbers.pxi
+++ b/tests/pixie/tests/test-numbers.pxi
@@ -73,3 +73,7 @@
   (t/assert (-num-eq 1000000000000000000000N (* 10000000
                                                 10000000
                                                 10000000))))
+
+(t/deftest test-wrap-around
+  (t/assert= Integer (type (unchecked-add 9223372036854775807 1)))
+  (t/assert (-num-eq -9223372036854775808 (unchecked-add 9223372036854775807 1))))


### PR DESCRIPTION
Related to issue #406. Added operations u+, u-, and u* for Integer, Float, BigInteger, and Ratio that follows the semantics of the checked operations except for cases of Integer and Integer. In these cases, the operations do not promote to BigInteger, but instead wrap like the equivalent C/C++ operations.

I also defined tests that mirror the tests for the checked operations, as well as added a test demonstrating the wrapping behaviour.