### PR TITLE
Improve support for additional load-paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,13 @@ compile_basics:
 	@echo -e "\n\n\n\nWARNING: Compiling core libs. If you want to modify one of these files delete the .pxic files first\n\n\n\n"
 	./pixie-vm -c pixie/uv.pxi -c pixie/io.pxi -c pixie/stacklets.pxi -c pixie/stdlib.pxi -c pixie/repl.pxi
 
-build_preload_with_jit: fetch_externals
+build_preload_with_jit: fetch_externals standard_path.py
 	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) --opt=jit target_preload.py 2>&1 >/dev/null | grep -v 'WARNING'
 
-build_preload_no_jit: fetch_externals
+build_preload_no_jit: fetch_externals standard_path.py
 	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) target_preload.py
 
-build: fetch_externals
+build: fetch_externals standard_path.py
 	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) $(JIT_OPTS) $(TARGET_OPTS)
 
 fetch_externals: $(EXTERNALS)/pypy ./lib

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all: help
 
 EXTERNALS=externals
 LIB_PATH=/usr/share/pixie/
+DESTDIR=/
 
 PYTHON ?= python2
 PYTHONPATH=$$PYTHONPATH:$(EXTERNALS)/pypy
@@ -85,9 +86,9 @@ standard_path.py:
 	echo "standard_path = \"$(LIB_PATH)\"" > $@
 
 install: pixie-vm
-	mkdir -p /usr/bin /usr/share/pixie
-	install pixie-vm /usr/bin/pixie
-	install pixie $(LIB_PATH)/pixie
+	mkdir -p $(DESTDIR)usr/bin $(DESTDIR)$(LIB_PATH)
+	install pixie-vm $(DESTDIR)usr/bin/pixie
+	install pixie $(DESTDIR)$(LIB_PATH)/pixie
 
 compile_tests:
 	find "tests" -name "*.pxi" | xargs -L1 ./pixie-vm -l "tests" -c

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all: help
 
+prefix=/usr
 EXTERNALS=externals
-LIB_PATH=/usr/share/pixie/
-DESTDIR=/
+LIB_PATH=$(prefix)/share/pixie/
+BIN_PATH=$(prefix)/bin/pixie
+DESTDIR=
 
 PYTHON ?= python2
 PYTHONPATH=$$PYTHONPATH:$(EXTERNALS)/pypy
@@ -86,9 +88,9 @@ standard_path.py:
 	echo "standard_path = \"$(LIB_PATH)\"" > $@
 
 install: pixie-vm
-	mkdir -p $(DESTDIR)usr/bin $(DESTDIR)$(LIB_PATH)
-	install pixie-vm $(DESTDIR)usr/bin/pixie
-	install pixie $(DESTDIR)$(LIB_PATH)/pixie
+	install -D pixie-vm $(DESTDIR)$(BIN_PATH)
+	install -d $(DESTDIR)$(LIB_PATH)
+	cp -R pixie $(DESTDIR)$(LIB_PATH)
 
 compile_tests:
 	find "tests" -name "*.pxi" | xargs -L1 ./pixie-vm -l "tests" -c

--- a/target.py
+++ b/target.py
@@ -236,6 +236,14 @@ def add_to_load_paths(path):
     rt.reset_BANG_(LOAD_PATHS.deref(), rt.conj(rt.deref(LOAD_PATHS.deref()), rt.wrap(path)))
 
 
+def add_env_to_load_path():
+    pp = os.environ.get("PIXIE_PATH")
+    if pp is not None:
+        LP = rt.deref(LOAD_PATHS.deref())
+        for path in pp.split(":"):
+            LP = rt.conj(LP, rt.wrap(path))
+        LOAD_PATHS.set_root(Atom(LP))
+
 def init_load_path(self_path):
     if not path.isfile(self_path):
         self_path = find_in_path(self_path)
@@ -248,6 +256,7 @@ def init_load_path(self_path):
     LOAD_PATHS.set_root(Atom(EMPTY_VECTOR.conj(rt.wrap(self_path))))
     # just for run_load_stdlib (global variables can't be assigned to)
     load_path.set_root(rt.wrap(self_path))
+    add_env_to_load_path()
 
 def dirname(path):
     return rpath.sep.join(path.split(rpath.sep)[0:-1])

--- a/target.py
+++ b/target.py
@@ -11,6 +11,7 @@ from pixie.vm.primitives import nil
 from pixie.vm.atom import Atom
 from pixie.vm.persistent_vector import EMPTY as EMPTY_VECTOR
 from pixie.vm.util import unicode_from_utf8, unicode_to_utf8
+from standard_path import standard_path
 import sys
 import os
 import os.path as path
@@ -257,6 +258,7 @@ def init_load_path(self_path):
     # just for run_load_stdlib (global variables can't be assigned to)
     load_path.set_root(rt.wrap(self_path))
     add_env_to_load_path()
+    LOAD_PATHS.set_root(Atom(rt.conj(rt.deref(LOAD_PATHS.deref()), rt.wrap(standard_path))))
 
 def dirname(path):
     return rpath.sep.join(path.split(rpath.sep)[0:-1])


### PR DESCRIPTION
This PR was motivated by me wanting to create an [AUR](https://aur.archlinux.org) package for pixie, but being blocked by the hard-coded `load-paths`. 

This PR contributes the following changes:

- load-paths are now added from the `PIXIE_PATH` environment variable when `pixie-vm` is run
- A single load path is added during build. This is intended for use by packagers to allow the standard library to be installed to a system directory such as `/usr/share/pixie`
- A `make install` target that more-or-less conforms to the variable conventions.

The order of the load-paths is [user path (-l), pixie-vm directory, PIXIE_PATH, system path].

Note that the pixie-vm path seems weird when doing a system install, because `/usr/bin` and a bunch of directories related to it end up in `load-paths`.