### PR TITLE
Avoids error message wit g++ as C++ compiler

### DIFF
--- a/examples/mandelbrot.pxi
+++ b/examples/mandelbrot.pxi
@@ -8,7 +8,7 @@
             [pixie.time :refer [time]]))
 
 (with-config {:library "SDL2"
-              :cxx-flags ["`sdl2-config --cflags`"]
+              :cxx-flags ["`sdl2-config --cflags`" "-std=c++0x"]
               :includes ["SDL.h"]}
 
   (defcfn SDL_Init)


### PR DESCRIPTION
GNU C++ issues an error on anonymous enum arguments used with `typename` in templates. `-std=c++0x` disables this error because the newer standard enables the usage. clang, the only other compiler option on supported architectures, works fine with the option (as well as without it).