### PR TITLE
add csp/timeout channel

### DIFF
--- a/pixie/csp.pxi
+++ b/pixie/csp.pxi
@@ -4,6 +4,7 @@
             [pixie.channels :as chans]))
 
 (def chan chans/chan)
+(def timeout chans/timeout)
 
 (defn close!
   "Closes the channel, future writes will be rejected, future reads will

--- a/tests/pixie/tests/test-csp.pxi
+++ b/tests/pixie/tests/test-csp.pxi
@@ -31,3 +31,18 @@
     (assert= (alts! [c] :default 42) [:default 42])
     (>! c 1)
     (assert= (alts! [c] :default 42) [c 1])))
+
+(deftest test-timeout-channel
+  (let [ts [(timeout 300)
+            (timeout 200)
+            (timeout 100)]]
+    (-> (go
+          (loop [ts (set ts)
+                 res []]
+            (if (empty? ts)
+              res
+              (let [[p _] (alts! ts)]
+                (recur (set (remove #{p} ts))
+                       (conj res p))))))
+        <!
+        (assert= (reverse ts)))))


### PR DESCRIPTION
It's the same as the core.async version. 

I did it using pixie.uv direcly, there might be a smarter way to do this using pixie.stacklets but I wasn't sure how. 