### PR TITLE
line-reader accepts a non buffered stream

### DIFF
--- a/pixie/io.pxi
+++ b/pixie/io.pxi
@@ -87,6 +87,10 @@
     (instance? BufferedInputStream input-stream)
     (-> input-stream ->LineReader)
 
+
+    (satisfies? IInputStream input-stream)
+    (-> input-stream (buffered-input-stream 1) ->LineReader)
+
     :else
     (throw [::Exception "Expected a LineReader, UTF8InputStream, or BufferedInputStream"])))
 


### PR DESCRIPTION
We create a buffered stream with a buffer size of one.