### PR TITLE
Add CFloat ffi type.

### DIFF
--- a/pixie/ffi-infer.pxi
+++ b/pixie/ffi-infer.pxi
@@ -104,11 +104,14 @@ return 0;
    (= (:type of-type) :function) (callback-type of-type in-struct?)
    :else 'pixie.stdlib/CVoidP))
 
+(def float-types {32 'pixie.stdlib/CFloat
+                  64 'pixie.stdlib/CDouble})
+                  
 (defmethod edn-to-ctype :float
-  [{:keys [size]} _]
-  (cond
-   (= size 8) 'pixie.stdlib/CDouble
-   :else (assert false "unknown type")))
+  [{:keys [size] :as tp} _]
+  (let [tp-found (get float-types (* 8 size))]
+    (assert tp-found (str "No type found for " tp))
+    tp-found))
 
 (defmethod edn-to-ctype :void
   [_ _]

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -350,6 +350,26 @@ class CInt(CType):
         return clibffi.cast_type_to_ffitype(rffi.INT)
 CInt()
 
+class CFloat(CType):
+    def __init__(self):
+        CType.__init__(self, u"pixie.stdlib.CFloat")
+
+    def ffi_get_value(self, ptr):
+        casted = rffi.cast(rffi.FLOATP, ptr)
+        return Float(rffi.cast(rffi.DOUBLE, casted[0]))
+
+    def ffi_set_value(self, ptr, val):
+        val = to_float(val)
+        casted = rffi.cast(rffi.FLOATP, ptr)
+        casted[0] = rffi.cast(rffi.FLOAT, val.float_val())
+
+    def ffi_size(self):
+        return rffi.sizeof(rffi.FLOAT)
+
+    def ffi_type(self):
+        return clibffi.cast_type_to_ffitype(rffi.FLOAT)
+CFloat()
+
 class CDouble(CType):
     def __init__(self):
         CType.__init__(self, u"pixie.stdlib.CDouble")

--- a/tests/pixie/tests/test-ffi.pxi
+++ b/tests/pixie/tests/test-ffi.pxi
@@ -1,6 +1,7 @@
 (ns pixie.tests.test-ffi
   (require pixie.test :as t)
-  (require pixie.math :as m))
+  (require pixie.math :as m)
+  (require pixie.ffi-infer :as i))
 
 
 
@@ -35,6 +36,17 @@
 
 (t/deftest test-ffi-infer
   (t/assert= 0.5 (m/asin (m/sin 0.5))))
+
+(t/deftest test-cdouble
+  (i/with-config {:library "m"
+                  :cxx-flags ["-lm"]
+                  :includes ["math.h"]}
+    (i/defcfn sinf)
+    (i/defcfn asinf)
+    (i/defcfn cosf)
+    (i/defcfn powf))
+  (t/assert= 0.5 (asinf (sinf 0.5)))
+  (t/assert= 1.0 (+ (powf (sinf 0.5) 2.0) (powf (cosf 0.5) 2.0))))
 
 
 (t/deftest test-ffi-callbacks


### PR DESCRIPTION
This is useful for interop with OpenGL (for example). 

As an aside, maybe the nomenclature should be `CFloat32` and `CFloat64` instead of `CFloat` and `CDouble`?