### PR TITLE
Add `eduction` and `completing`

### DIFF
--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -574,6 +574,34 @@
   (t/assert= (take 5 (cycle '(1 2))) '(1 2 1 2 1))
   (t/assert= (take 3 (cycle [nil])) '(nil nil nil)))
 
+(t/deftest test-eduction
+  ;; one xform
+  (t/assert= [1 2 3 4 5]
+             (eduction (map inc) (range 5)))
+  ;; multiple xforms
+  (t/assert= ["2" "4"]
+             (eduction (map inc) (filter even?) (map str) (range 5)))
+  ;; materialize at the end
+  ;; TODO: For when sort is implemented
+  ;; (t/assert= [1 1 1 1 2 2 2 3 3 4]
+  ;;            (->> (range 5)
+  ;;                 (eduction (mapcat range) (map inc))
+  ;;                 sort))
+  (t/assert= [1 1 2 1 2 3 1 2 3 4]
+             (vec (->> (range 5)
+                       (eduction (mapcat range) (map inc)))))
+  (t/assert= {1 4, 2 3, 3 2, 4 1}
+             (->> (range 5)
+                  (eduction (mapcat range) (map inc))
+                  frequencies))
+  (t/assert= ["tac" "god" "hsif" "drib" "kravdraa"]
+             (->> ["cat" "dog" "fish" "bird" "aardvark"]
+                  (eduction (map pixie.string/reverse))
+                  (seq)))
+  ;; expanding transducer with nils
+  (t/assert= '(1 2 3 nil 4 5 6 nil)
+             (eduction cat [[1 2 3 nil] [4 5 6 nil]])))
+
 (t/deftest test-trace
   (try
     (/ 0 0)

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -582,11 +582,6 @@
   (t/assert= ["2" "4"]
              (eduction (map inc) (filter even?) (map str) (range 5)))
   ;; materialize at the end
-  ;; TODO: For when sort is implemented
-  ;; (t/assert= [1 1 1 1 2 2 2 3 3 4]
-  ;;            (->> (range 5)
-  ;;                 (eduction (mapcat range) (map inc))
-  ;;                 sort))
   (t/assert= [1 1 2 1 2 3 1 2 3 4]
              (vec (->> (range 5)
                        (eduction (mapcat range) (map inc)))))


### PR DESCRIPTION
The `eduction` function was added, as requested in issue #483.

The implementation and the tests were imported and adapted from
Clojure's standard library (from [1] and [2], respectively).

Since Clojure's implementation uses it, the function `completing` was
imported as well (from the same source).

As of now, Pixie's stdlib lacks a `sort`/`sort-by` function, one of the
tests is disabled (commented out), and another is modified in order to
avoid the call to `sort-by`.

Sources:
Both from Clojure's main repo, fetched at commit `3b98a00`.
[1] https://github.com/clojure/clojure/blob/3b98a00e86f961550fb2eaee64e70754e04d1089/src/clj/clojure/core.clj#L7339
[2] https://github.com/clojure/clojure/blob/3b98a00e86f961550fb2eaee64e70754e04d1089/test/clojure/test_clojure/transducers.clj