### PR TITLE
make typing less verbose

### DIFF
--- a/pixie/vm/array.py
+++ b/pixie/vm/array.py
@@ -14,8 +14,6 @@ UNROLL_IF_SMALLER_THAN = 8
 class Array(object.Object):
     _type = object.Type(u"pixie.stdlib.Array")
     _immutable_fields_ = ["_list"]
-    def type(self):
-        return Array._type
 
     def __init__(self, lst):
         self._list = lst
@@ -98,9 +96,6 @@ class ArraySeq(object.Object):
             init = f.invoke([init, rt.nth(self._w_array, rt.wrap(x))])
         return init
 
-    def type(self):
-        return self._type
-
 @extend(proto._first, ArraySeq)
 def _first(self):
     assert isinstance(self, ArraySeq)
@@ -173,9 +168,6 @@ class ByteArray(object.Object):
         self._buffer = lltype.malloc(ARRAY_OF_UCHAR, size, flavor="raw")
         for x in range(size):
             self._buffer[x] = chr(0)
-
-    def type(self):
-        return ByteArray._type
 
 
     def __del__(self):

--- a/pixie/vm/atom.py
+++ b/pixie/vm/atom.py
@@ -7,9 +7,6 @@ import pixie.vm.stdlib as proto
 class Atom(object.Object):
     _type = object.Type(u"pixie.stdlib.Atom")
 
-    def type(self):
-        return Atom._type
-
     def with_meta(self, meta):
         return Atom(self._boxed_value, meta)
 

--- a/pixie/vm/code.py
+++ b/pixie/vm/code.py
@@ -148,9 +148,6 @@ class MultiArityFn(BaseCode):
 
     _immutable_fields_ = ["_arities[*]", "_required_arity", "_rest_fn"]
 
-    def type(self):
-        return MultiArityFn._type
-
     def __init__(self, name, arities, required_arity=0, rest_fn=None, meta=nil):
         BaseCode.__init__(self)
         self._name = name
@@ -199,9 +196,6 @@ class NativeFn(BaseCode):
     def __init__(self, doc=None):
         BaseCode.__init__(self)
 
-    def type(self):
-        return NativeFn._type
-
     def invoke(self, args):
         return self.inner_invoke(args)
 
@@ -216,9 +210,6 @@ class Code(BaseCode):
     """Interpreted code block. Contains consts and """
     _type = object.Type(u"pixie.stdlib.Code")
     _immutable_fields_ = ["_arity", "_consts[*]", "_bytecode", "_stack_size", "_meta", "_debug_points"]
-
-    def type(self):
-        return Code._type
 
     def __init__(self, name, arity, bytecode, consts, stack_size, debug_points, meta=nil):
         BaseCode.__init__(self)
@@ -277,9 +268,6 @@ class VariadicCode(BaseCode):
     _immutable_fields_ = ["_required_arity", "_code", "_meta"]
     _type = object.Type(u"pixie.stdlib.VariadicCode")
 
-    def type(self):
-        return VariadicCode._type
-
     def __init__(self, code, required_arity, meta=nil):
         BaseCode.__init__(self)
         self._required_arity = r_uint(required_arity)
@@ -319,9 +307,6 @@ class Closure(BaseCode):
     _type = object.Type(u"pixie.stdlib.Closure")
     _immutable_fields_ = ["_closed_overs[*]", "_code", "_meta"]
     
-    def type(self):
-        return Closure._type
-
     def __init__(self, code, closed_overs, meta=nil):
         BaseCode.__init__(self)
         affirm(isinstance(code, Code), u"Code argument to Closure must be an instance of Code")
@@ -373,9 +358,6 @@ class Closure(BaseCode):
 class Undefined(object.Object):
     _type = object.Type(u"pixie.stdlib.Undefined")
 
-    def type(self):
-        return Undefined._type
-
 undefined = Undefined()
 
 
@@ -412,9 +394,6 @@ class DynamicVars(py_object):
 class Var(BaseCode):
     _type = object.Type(u"pixie.stdlib.Var")
     _immutable_fields_ = ["_ns_ref"]
-
-    def type(self):
-        return Var._type
 
     def __init__(self, ns_ref, ns, name):
         BaseCode.__init__(self)
@@ -496,9 +475,6 @@ class Namespace(object.Object):
     _type = object.Type(u"pixie.stdlib.Namespace")
 
     _immutable_fields_ = ["_rev?"]
-
-    def type(self):
-        return Namespace._type
 
     def __init__(self, name):
         self._rev = 0
@@ -636,9 +612,6 @@ class Protocol(object.Object):
 
     _immutable_fields_ = ["_rev?"]
 
-    def type(self):
-        return Protocol._type
-
     def __init__(self, name):
         self._name = name
         self._polyfns = {}
@@ -662,9 +635,6 @@ class Protocol(object.Object):
 
 class PolymorphicFn(BaseCode):
     _type = object.Type(u"pixie.stdlib.PolymorphicFn")
-
-    def type(self):
-        return PolymorphicFn._type
 
     _immutable_fields_ = ["_rev?"]
 
@@ -744,9 +714,6 @@ class PolymorphicFn(BaseCode):
 class DoublePolymorphicFn(BaseCode):
     """A function that is polymorphic on the first two arguments"""
     _type = object.Type(u"pixie.stdlib.DoublePolymorphicFn")
-
-    def type(self):
-        return DefaultProtocolFn._type
 
     _immutable_fields_ = ["_rev?"]
 

--- a/pixie/vm/cons.py
+++ b/pixie/vm/cons.py
@@ -7,9 +7,6 @@ from  pixie.vm.code import extend, as_var
 class Cons(object.Object):
     _type = object.Type(u"pixie.stdlib.Cons")
 
-    def type(self):
-        return Cons._type
-
     def __init__(self, head, tail, meta=nil):
         self._first = head
         self._next = tail

--- a/pixie/vm/custom_types.py
+++ b/pixie/vm/custom_types.py
@@ -216,8 +216,6 @@ def get_field(inst, field):
 
 class AbstractMutableCell(Object):
     _type = Type(u"pixie.stdlib.AbstractMutableCell")
-    def type(self):
-        return self._type
 
     def set_mutable_cell_value(self, ct, fields, nm, idx, value):
         pass

--- a/pixie/vm/interpreter.py
+++ b/pixie/vm/interpreter.py
@@ -159,10 +159,6 @@ class ShallowContinuation(Object):
         self._frame = frame
         self._val = val
 
-    def type(self):
-        return ShallowContinuation._type
-
-
     def is_finished(self):
         return self._frame.finished
 

--- a/pixie/vm/lazy_seq.py
+++ b/pixie/vm/lazy_seq.py
@@ -9,9 +9,6 @@ import rpython.rlib.jit as jit
 class LazySeq(object.Object):
     _type = object.Type(u"pixie.stdlib.LazySeq")
 
-    def type(self):
-        return LazySeq._type
-
     def __init__(self, fn, meta=nil):
         self._fn = fn
         self._meta = meta

--- a/pixie/vm/libs/env.py
+++ b/pixie/vm/libs/env.py
@@ -10,9 +10,6 @@ import os
 class Environment(Object):
     _type = Type(u"pixie.stdlib.Environment")
 
-    def type(self):
-        return Environment._type
-
     def val_at(self, key, not_found):
         if not isinstance(key, String):
             runtime_error(u"Environment variables are strings ")

--- a/pixie/vm/libs/ffi.py
+++ b/pixie/vm/libs/ffi.py
@@ -41,9 +41,6 @@ class CType(object.Type):
 class ExternalLib(object.Object):
     _type = object.Type(u"pixie.stdlib.ExternalLib")
 
-    def type(self):
-        return ExternalLib._type
-
     def __init__(self, nm):
         assert isinstance(nm, unicode)
         self._name = nm
@@ -93,9 +90,6 @@ class ExternalLib(object.Object):
 class FFIFn(object.Object):
     _type = object.Type(u"pixie.stdlib.FFIFn")
     _immutable_fields_ = ["_name", "_f_ptr", "_c_fn_type"]
-
-    def type(self):
-        return FFIFn._type
 
     def __init__(self, name, fn_ptr, c_fn_type):
         assert isinstance(c_fn_type, CFunctionType)
@@ -218,9 +212,6 @@ class Buffer(PointerType):
     """ Defines a byte buffer with non-gc'd (therefore non-movable) contents
     """
     _type = object.Type(u"pixie.stdlib.Buffer")
-
-    def type(self):
-        return Buffer._type
 
     def __init__(self, size):
         self._size = size
@@ -502,8 +493,6 @@ cvoidp = CVoidP()
 
 class VoidP(PointerType):
     _type = cvoidp
-    def type(self):
-        return VoidP._type
 
     def __init__(self, raw_data):
         self._raw_data = raw_data
@@ -603,9 +592,6 @@ class CCallback(PointerType):
         self._raw_closure = raw_closure
         self._is_invoked = False
         self._unique_id = id
-
-    def type(self):
-        return CCallback._type
 
     def get_raw_closure(self):
         return self._raw_closure

--- a/pixie/vm/libs/path.py
+++ b/pixie/vm/libs/path.py
@@ -8,9 +8,6 @@ import os
 class Path(Object):
     _type = Type(u"pixie.path.Path")
 
-    def type(self):
-        return Path._type
-
     def __init__(self, top):
         self._path = rt.name(top)
 

--- a/pixie/vm/libs/pxic/writer.py
+++ b/pixie/vm/libs/pxic/writer.py
@@ -73,8 +73,6 @@ class Writer(object):
 
 class WriterBox(Object):
     _type = Type(u"pixie.stdlib.WriterBox")
-    def type(self):
-        return WriterBox._type
 
     def __init__(self, wtr):
         self._pxic_writer = wtr

--- a/pixie/vm/map_entry.py
+++ b/pixie/vm/map_entry.py
@@ -6,9 +6,6 @@ from  pixie.vm.code import extend, as_var
 class MapEntry(object.Object):
     _type = object.Type(u"pixie.stdlib.MapEntry")
 
-    def type(self):
-        return MapEntry._type
-
     def __init__(self, key, val):
         self._key = key
         self._val = val

--- a/pixie/vm/numbers.py
+++ b/pixie/vm/numbers.py
@@ -13,9 +13,6 @@ import math
 class Number(object.Object):
     _type = object.Type(u"pixie.stdlib.Number")
 
-    def type(self):
-        return Number._type
-
 class Integer(Number):
     _type = object.Type(u"pixie.stdlib.Integer", Number._type)
     _immutable_fields_ = ["_int_val"]
@@ -32,9 +29,6 @@ class Integer(Number):
     def promote(self):
         return Integer(jit.promote(self._int_val))
 
-    def type(self):
-        return Integer._type
-
 zero_int = Integer(0)
 one_int = Integer(1)
 
@@ -48,9 +42,6 @@ class BigInteger(Number):
     def bigint_val(self):
         return self._bigint_val
 
-    def type(self):
-        return BigInteger._type
-
 class Float(Number):
     _type = object.Type(u"pixie.stdlib.Float", Number._type)
     _immutable_fields_ = ["_float_val"]
@@ -60,9 +51,6 @@ class Float(Number):
 
     def float_val(self):
         return self._float_val
-
-    def type(self):
-        return Float._type
 
 class Ratio(Number):
     _type = object.Type(u"pixie.stdlib.Ratio", Number._type)
@@ -78,9 +66,6 @@ class Ratio(Number):
 
     def denominator(self):
         return self._denominator
-
-    def type(self):
-        return Ratio._type
 
 @wrap_fn
 def ratio_write(obj):

--- a/pixie/vm/object.py
+++ b/pixie/vm/object.py
@@ -26,8 +26,12 @@ class Object(object):
     """
     _attrs_ = ()
 
+    # Initialized after Type is defined.
+    _type = None
+
     def type(self):
-        affirm(False, u".type isn't overloaded")
+        assert(isinstance(self.__class__._type, Type))
+        return self.__class__._type
 
     @jit.unroll_safe
     def invoke(self, args):
@@ -109,9 +113,6 @@ class Type(Object):
     def name(self):
         return self._name
 
-    def type(self):
-        return Type._type
-
     def parent(self):
         return self._parent
 
@@ -156,9 +157,6 @@ class RuntimeException(Object):
         self._msg = msg
         self._data = data
         self._trace = []
-
-    def type(self):
-        return RuntimeException._type
 
     def __repr__(self):
         import pixie.vm.rt as rt
@@ -211,8 +209,7 @@ def safe_invoke(f, args):
 
 class ErrorInfo(Object):
     _type = Type(u"pixie.stdlib.ErrorInfo")
-    def type(self):
-        return ErrorInfo._type
+
     def __init__(self):
         pass
 

--- a/pixie/vm/persistent_hash_map.py
+++ b/pixie/vm/persistent_hash_map.py
@@ -19,9 +19,6 @@ class Box(py_object):
 class PersistentHashMap(object.Object):
     _type = object.Type(u"pixie.stdlib.PersistentHashMap")
 
-    def type(self):
-        return PersistentHashMap._type
-
     def __init__(self, cnt, root, meta=nil):
         self._cnt = cnt
         self._root = root
@@ -61,9 +58,6 @@ class PersistentHashMap(object.Object):
 
 class INode(object.Object):
     _type = object.Type(u"pixie.stdlib.INode")
-
-    def type(self):
-        return INode._type
 
     def assoc_inode(self, shift, hash_val, key, val, added_leaf):
         pass

--- a/pixie/vm/persistent_hash_set.py
+++ b/pixie/vm/persistent_hash_set.py
@@ -12,9 +12,6 @@ VAR_KEY = intern_var(u"pixie.stdlib", u"key")
 class PersistentHashSet(object.Object):
     _type = object.Type(u"pixie.stdlib.PersistentHashSet")
 
-    def type(self):
-        return PersistentHashSet._type
-
     def __init__(self, meta, m):
         self._meta = meta
         self._map = m

--- a/pixie/vm/persistent_list.py
+++ b/pixie/vm/persistent_list.py
@@ -8,9 +8,6 @@ import pixie.vm.rt as rt
 class PersistentList(object.Object):
     _type = object.Type(u"pixie.stdlib.PersistentList")
 
-    def type(self):
-        return PersistentList._type
-
     def __init__(self, head, tail, cnt, meta=nil):
         self._first = head
         self._next = tail
@@ -100,8 +97,6 @@ def _with_meta(self, meta):
     
 class EmptyList(object.Object):
     _type = object.Type(u"pixie.stdlib.EmptyList")
-    def type(self):
-        return EmptyList._type
     
     def __init__(self, meta=nil):
         self._meta = meta

--- a/pixie/vm/persistent_vector.py
+++ b/pixie/vm/persistent_vector.py
@@ -13,9 +13,6 @@ import pixie.vm.rt as rt
 class Node(object.Object):
     _type = object.Type(u"pixie.stdlib.PersistentVectorNode")
 
-    def type(self):
-        return Node._type
-
     def __init__(self, edit, array=None):
         self._edit = edit
         self._array = [None] * 32 if array is None else array
@@ -26,9 +23,6 @@ EMPTY_NODE = Node(None)
 
 class PersistentVector(object.Object):
     _type = object.Type(u"pixie.stdlib.PersistentVector")
-
-    def type(self):
-        return PersistentVector._type
 
     def __init__(self, meta, cnt, shift, root, tail):
         self._meta = meta
@@ -210,9 +204,6 @@ edited = u"edited"
 
 class TransientVector(object.Object):
     _type = object.Type(u"pixie.stdlib.TransientVector")
-
-    def type(self):
-        return TransientVector._type
 
     def __init__(self, cnt, shift, root, tail):
         self._cnt = cnt

--- a/pixie/vm/primitives.py
+++ b/pixie/vm/primitives.py
@@ -1,25 +1,15 @@
 import pixie.vm.object as object
 
-
 class Nil(object.Object):
     _type = object.Type(u"pixie.stdlib.Nil")
 
     def __repr__(self):
         return u"nil"
 
-    def type(self):
-        return Nil._type
-
-
 nil = Nil()
-
 
 class Bool(object.Object):
     _type = object.Type(u"pixie.stdlib.Bool")
-
-    def type(self):
-        return Bool._type
-
 
 true = Bool()
 false = Bool()

--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -43,9 +43,6 @@ ARG_ENV.set_root(nil)
 class PlatformReader(object.Object):
     _type = object.Type(u"PlatformReader")
 
-    def type(self):
-        return PlatformReader._type
-
     def read(self):
         assert False
 
@@ -57,8 +54,6 @@ class PlatformReader(object.Object):
 
 class StringReader(PlatformReader):
     _type = object.Type(u"pixie.stdlib.StringReader")
-    def type(self):
-        return StringReader._type
 
     def __init__(self, s):
         affirm(isinstance(s, unicode), u"StringReader requires unicode")
@@ -111,8 +106,6 @@ def reader_fn(fn):
 
 class LinePromise(object.Object):
     _type = object.Type(u"pixie.stdlib.LinePromise")
-    def type(self):
-        return LinePromise._type
 
     def __init__(self):
         self._chrs = []
@@ -769,9 +762,6 @@ def read_symbol(rdr, ch):
 
 class EOF(object.Object):
     _type = object.Type(u"EOF")
-
-    def type(self):
-        return EOF._type
 
 
 eof = EOF()

--- a/pixie/vm/reduced.py
+++ b/pixie/vm/reduced.py
@@ -6,8 +6,6 @@ import pixie.vm.stdlib as proto
 
 class Reduced(object.Object):
     _type = object.Type(u"pixie.stdlib.Reduced")
-    def type(self):
-        return Reduced._type
 
     def __init__(self, boxed_value):
         self._boxed_value = boxed_value

--- a/pixie/vm/stacklet.py
+++ b/pixie/vm/stacklet.py
@@ -25,9 +25,6 @@ class StackletHandle(Object):
         self._stacklet_handle = h
         self._used = False
 
-    def type(self):
-        return self._type
-
     def invoke(self, args):
         affirm(not self._used, u"Can only call a given stacklet handle once.")
         affirm(len(args) == 1, u"Only one arg should be handed to a stacklet handle")

--- a/pixie/vm/string.py
+++ b/pixie/vm/string.py
@@ -11,9 +11,6 @@ from pixie.vm.libs.pxic.util import add_marshall_handlers
 class String(Object):
     _type = Type(u"pixie.stdlib.String")
 
-    def type(self):
-        return String._type
-
     def __init__(self, s):
         #assert isinstance(s, unicode)
         self._str = s
@@ -75,9 +72,6 @@ def _eq(self, v):
 class Character(Object):
     _type = Type(u"pixie.stdlib.Character")
     _immutable_fields_ = ["_char_val"]
-
-    def type(self):
-        return Character._type
 
     def __init__(self, i):
         assert isinstance(i, int)

--- a/pixie/vm/string_builder.py
+++ b/pixie/vm/string_builder.py
@@ -6,9 +6,6 @@ import pixie.vm.stdlib as proto
 class StringBuilder(Object):
     _type = Type(u"pixie.stdlib.StringBuilder")
 
-    def type(self):
-        return StringBuilder._type
-
     def __init__(self):
         self._strs = []
 

--- a/pixie/vm/threads.py
+++ b/pixie/vm/threads.py
@@ -65,9 +65,6 @@ class Lock(Object):
     def __init__(self, ll_lock):
         self._ll_lock = ll_lock
 
-    def type(self):
-        return Lock._type
-
 
 @as_var("-create-lock")
 def _create_lock():

--- a/pixie/vm/util.py
+++ b/pixie/vm/util.py
@@ -78,9 +78,6 @@ import pixie.vm.rt as rt
 class HashingState(Object):
     _type = Type(u"pixie.stdlib.HashingState")
 
-    def type(self):
-        return HashingState._type
-
     def __init__(self):
         self._n = r_uint(0)
         self._hash = r_uint(1)


### PR DESCRIPTION
Object's type method is now used by default so all
subtypes can use the inherited implementation