### PR TITLE
find python using which -a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: help
 
 EXTERNALS=externals
 
-PYTHON ?= python2
+PYTHON ?= `env which -a python2 python2.7 | head -n1`
 PYTHONPATH=$$PYTHONPATH:$(EXTERNALS)/pypy
 
 


### PR DESCRIPTION
python2 does not exist on osx, use `env which -a python2 python2.7` if none provided