### PR TITLE
[wip] Regular expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ compile_src:
 	find * -name "*.pxi" | grep "^pixie/" | xargs -L1 ./pixie-vm $(EXTERNALS_FLAGS) -c
 
 clean_pxic:
-	find * -name "*.pxic" | xargs --no-run-if-empty rm
+	find * -name "*.pxic" -delete
 
 clean: clean_pxic
 	rm -rf ./lib

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ compile_basics:
 build: fetch_externals
 	$(PYTHON) $(EXTERNALS)/pypy/rpython/bin/rpython $(COMMON_BUILD_OPTS) $(JIT_OPTS) $(TARGET_OPTS)
 
-fetch_externals: $(EXTERNALS)/pypy externals.fetched
+fetch_externals: $(EXTERNALS)/pypy $(EXTERNALS)/cre2 externals.fetched
 
 externals.fetched:
 	echo https://github.com/pixie-lang/external-deps/releases/download/1.0/`uname -s`-`uname -m`.tar.bz2
@@ -49,14 +49,29 @@ externals.fetched:
 	tar -jxf /tmp/externals.tar.bz2 --strip-components=2
 	touch externals.fetched
 
-
-$(EXTERNALS)/pypy:
-	mkdir $(EXTERNALS); \
+$(EXTERNALS)/pypy: $(EXTERNALS)
 	cd $(EXTERNALS); \
 	curl https://bitbucket.org/pypy/pypy/get/81254.tar.bz2 >  pypy.tar.bz2; \
 	mkdir pypy; \
 	cd pypy; \
 	tar -jxf ../pypy.tar.bz2 --strip-components=1
+
+$(EXTERNALS)/re2: $(EXTERNALS)
+	cd $(EXTERNALS) && \
+	curl -sL https://github.com/google/re2/archive/2016-02-01.tar.gz > re2.tar.gz && \
+  mkdir re2 && \
+  cd re2 && \
+	tar -jxf ../re2.tar.gz --strip-components=1
+
+$(EXTERNALS)/cre2: $(EXTERNALS)/re2
+	cd $(EXTERNALS) && \
+	curl -sL https://github.com/marcomaggi/cre2/archive/0.1b6.tar.gz > cre2.tar.gz && \
+  mkdir cre2 && \
+  cd cre2 && \
+	tar -jxf ../cre2.tar.gz --strip-components=1
+
+$(EXTERNALS):
+	mkdir $(EXTERNALS)
 
 run:
 	./pixie-vm

--- a/pixie/regex.pxi
+++ b/pixie/regex.pxi
@@ -6,4 +6,65 @@
                             "-lcre2"
                             "-Iexternals/cre2/src"]
                 :includes ["cre2.h"]}
-  (i/defcfn cre2_version_string))
+
+  (i/defcstruct cre2_string_t [:data :length])
+  (i/defcfn cre2_version_string)
+
+  ;; Options
+  (i/defcfn cre2_opt_new)
+  (i/defcfn cre2_opt_delete)
+  (i/defcfn cre2_opt_set_posix_syntax)
+  (i/defcfn cre2_opt_set_longest_match)
+  (i/defcfn cre2_opt_set_log_errors)
+  (i/defcfn cre2_opt_set_literal)
+  (i/defcfn cre2_opt_set_never_nl)
+  (i/defcfn cre2_opt_set_case_sensitive)
+  (i/defcfn cre2_opt_set_perl_classes)
+  (i/defcfn cre2_opt_set_word_boundary)
+  (i/defcfn cre2_opt_set_one_line)
+  (i/defcfn cre2_opt_set_max_mem)
+  (i/defcfn cre2_opt_set_encoding)
+
+  ;; Construction / destruction
+  (i/defcfn cre2_new)
+  (i/defcfn cre2_delete)
+
+  ;; Inspection
+  (i/defcfn cre2_pattern)
+  (i/defcfn cre2_error_code)
+  (i/defcfn cre2_num_capturing_groups)
+  (i/defcfn cre2_program_size)
+
+  ;; Errors something?
+  (i/defcfn cre2_error_string)
+  (i/defcfn cre2_error_arg)
+
+  ;; Matching
+  (i/defcstruct cre2_range_t [:start :past])
+  (i/defcfn cre2_match)
+  (i/defcfn cre2_easy_match)
+  (i/defcfn cre2_strings_to_ranges)
+)
+
+(def optmap
+  { :ascii #(cre2_set_encoding % 2)
+    :posix #(cre2_opt_set_posix_syntax % 1)
+    :longest_match #(cre2_opt_set_longest_match % 1)
+    :silent #(cre2_opt_set_log_errors % 0)
+    :literal #(cre2_opt_set_literal % 1)
+    :never_nl #(cre2_opt_set_never_nl % 1)
+    :dot_nl #(cre2_opt_set_one_line % 0)
+    :never_capture #(do %) ;; ??
+    :ignore_case #(cre2_opt_set_case_sensitive % 0) })
+
+(defn- cre2-opts [opts]
+  (let [opt (cre2_opt_new)]
+    (doseq [key opts] ((key optmap) opt))
+    opt))
+
+(defn regexp
+  {:doc "Returns internal representation for regular
+   expression, used in matching functions."
+   :signatures [[rexegp-str opts]]}
+  [regexp-str opts]
+  (cre2_new regexp-str (count regexp-str) (cre2-opts opts)))

--- a/pixie/regex.pxi
+++ b/pixie/regex.pxi
@@ -1,0 +1,25 @@
+(ns pixie.regex
+  (:require [pixie.ffi-infer :as i]))
+
+(i/with-config {:library "re2"
+                :cxx-flags ["-lre2"]
+                :includes ["re2.h"]}
+  (i/defconst M_E)
+  (i/defconst M_LOG2E)
+  (i/defconst M_LOG10E)
+  (i/defconst M_LN2)
+  (i/defconst M_LN10)
+  (i/defconst M_PI)
+  (i/defconst M_PI_2)
+  (i/defconst M_PI_4)
+  (i/defconst M_1_PI)
+  (i/defconst M_2_PI)
+  (i/defconst M_2_SQRTPI)
+  (i/defconst M_SQRT2)
+  (i/defconst M_SQRT1_2)
+
+  (i/defcfn nan)
+  (i/defcfn ceil)
+  (i/defcfn floor)
+  (i/defcfn nearbyint)
+  (i/defcfn rint)

--- a/pixie/regex.pxi
+++ b/pixie/regex.pxi
@@ -1,25 +1,12 @@
 (ns pixie.regex
   (:require [pixie.ffi-infer :as i]))
 
-(i/with-config {:library "re2"
-                :cxx-flags ["-lre2"]
-                :includes ["re2.h"]}
+(i/with-config {:library "cre2"
+                :cxx-flags [" && pwd"
+                            "-Lexternals/cre2/build/.libs"
+                            "-lcre2"
+                            "-Iexternals/cre2/src"]
+                :includes ["cre2.h"]}
   (i/defconst M_E)
-  (i/defconst M_LOG2E)
-  (i/defconst M_LOG10E)
-  (i/defconst M_LN2)
-  (i/defconst M_LN10)
-  (i/defconst M_PI)
-  (i/defconst M_PI_2)
-  (i/defconst M_PI_4)
-  (i/defconst M_1_PI)
-  (i/defconst M_2_PI)
-  (i/defconst M_2_SQRTPI)
-  (i/defconst M_SQRT2)
-  (i/defconst M_SQRT1_2)
 
-  (i/defcfn nan)
-  (i/defcfn ceil)
-  (i/defcfn floor)
-  (i/defcfn nearbyint)
-  (i/defcfn rint)
+  (i/defcfn rint))

--- a/pixie/regex.pxi
+++ b/pixie/regex.pxi
@@ -2,11 +2,8 @@
   (:require [pixie.ffi-infer :as i]))
 
 (i/with-config {:library "cre2"
-                :cxx-flags [" && pwd"
-                            "-Lexternals/cre2/build/.libs"
+                :cxx-flags ["-Lexternals/cre2/build/.libs"
                             "-lcre2"
                             "-Iexternals/cre2/src"]
                 :includes ["cre2.h"]}
-  (i/defconst M_E)
-
-  (i/defcfn rint))
+  (i/defcfn cre2_version_string))

--- a/pixie/regex.pxi
+++ b/pixie/regex.pxi
@@ -68,3 +68,15 @@
    :signatures [[rexegp-str opts]]}
   [regexp-str opts]
   (cre2_new regexp-str (count regexp-str) (cre2-opts opts)))
+
+(defn match
+  [pattern text]
+  (cre2_match
+   pattern
+   text
+   (count text)
+   0
+   (count text)
+   1 ;; anchor 1 - no, 2 - start, 3 - both
+   (cre2_string_t)
+   (+ 1 (cre2_num_capturing_groups pattern))))

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -3073,13 +3073,6 @@ ex: (vary-meta x assoc :foo 42)"
             ret)
           val)))))
 
-(defn regexp
-  {:doc "Returns internal representation for regular
-   expression, used in matching functions."
-   :signatures [[rexegp-str opts]]}
-  [regexp-str opts]
-  (println (str regexp-str " " opts)))
-
 (deftype Iterate [f x]
   IReduce
   (-reduce [self rf init]

--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -3072,3 +3072,10 @@ ex: (vary-meta x assoc :foo 42)"
             (swap! cache assoc argsv ret)
             ret)
           val)))))
+
+(defn regexp
+  {:doc "Returns internal representation for regular
+   expression, used in matching functions."
+   :signatures [[rexegp-str opts]]}
+  [regexp-str opts]
+  (println (str regexp-str " " opts)))

--- a/pixie/vm/reader.py
+++ b/pixie/vm/reader.py
@@ -648,7 +648,7 @@ class RegexReader(ReaderHandler):
             except EOFError:
                 break
 
-        return rt.cons(symbol(u"re2"), rt.cons(regex_str, rt.cons(regex_opts, nil)))
+        return rt.cons(symbol(u"regexp"), rt.cons(regex_str, rt.cons(regex_opts, nil)))
 
 dispatch_handlers = {
     u"{": SetReader(),


### PR DESCRIPTION
first of all, this is not merge-ready. this PR introduces regexp literal and builds cre2 C library that wraps google's re2. to get all of it working you need:

- build pixie-vm normally
- `make re2_cre2` - this will build re2 and cre2 wrapper in externals/
- `ln -s 'pwd'/externals/cre2/build/.libs/libcre2* /usr/local/lib/` - i have no idea what i'm doing
- `pixie-vm -c pixie/regex.pxi` - this might require something like `export DYLD_LIBRARY_PATH='pwd'/externals/cre2/build/.libs`, see previous point

after this is done, fire up your repl and run `(ns user (:require [pixie.regex :refer [regexp match]]))`

this PR introduces regexp literal like in clojure:

`#"123"` - is translated in RegexReader into `(regexp "123" #{})`
`#"123"iL` - is translated into`(regexp "123" #{:ignore_case :literal})`

most options available in `re2` are supported

```clojure
user => (match #"123" "123")
1
user => (match #"123" "124")
0
```

this is how far i got and i will certainly need help from somebody more knowledgable in building and using C libraries.