### PR TITLE
Macro q deref

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2726,7 +2726,7 @@ Calling this function on something that is not ISeqable returns a seq with that 
           (= () form))
     form
     (let [[sym & args] form
-          fvar (resolve sym)]
+          fvar (resolve-in *ns* sym)]
       (if (and fvar (macro? @fvar))
         (apply @fvar args)
         form))))

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -687,7 +687,8 @@ def set_macro(f):
 
 @returns(bool)
 @as_var("macro?")
-def macro_QMARK_(f):
+def macro_QMARK_(v):
+    f = v.deref() if isinstance(v, Var) else v
     return true if isinstance(f, BaseCode) and f.is_macro() else false
 
 @returns(unicode)


### PR DESCRIPTION
i noticed macroexpand-1 doesn't work in repl, for instance in master is following:

```clojure
user => (defmacro x [n] `(quote ~n))
<inst pixie.stdlib.Code>
user => (macroexpand-1 '(x q))
(x q)
```

PR makes this happen:

```clojure
user => (defmacro x [n] `(quote ~n))
<inst pixie.stdlib.Code>
user => (macroexpand-1 '(x q))
(quote q)
```

things that are broken(?):
- `(resolve 'x)` will return `Var` where `(macro? ...)` expects instance of `Code`, hence the `.deref()` in `macro_QMARK_`
- `(resolve 'x)` will also use `(this-ns-name)` which evaluates to `pixie.stdlib` when we should be looking in `user`, replaced `resolve` with `resolve-in *ns*` <- i'm not sure i fully understand what i'm doing here