### PR TITLE
[wip] in-ns form

### DIFF
--- a/pixie/vm/compiler.py
+++ b/pixie/vm/compiler.py
@@ -759,13 +759,6 @@ def compile_yield(form, ctx):
     compile_form(arg, ctx)
     ctx.bytecode.append(code.YIELD)
 
-def compile_in_ns(form, ctx):
-    affirm(rt.count(form) == 2, u"in-ns requires an argument")
-    arg = rt.first(rt.next(form))
-    NS_VAR.set_value(code._ns_registry.find_or_make(rt.name(arg)))
-    NS_VAR.deref().include_stdlib()
-    compile_fn_call(form, ctx)
-
 def compile_local_macro(form, ctx):
     form = rt.next(form)
     binding = rt.first(form)
@@ -799,7 +792,6 @@ builtins = {u"fn*": compile_fn,
             u"var": compile_var,
             u"catch": compile_catch,
             u"this-ns-name": compile_this_ns,
-            u"in-ns": compile_in_ns, # yes, this is both a function and a compiler special form.
             u"yield": compile_yield,
             u"local-macro": compile_local_macro}
 

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -485,25 +485,6 @@
                 '(0 1 2 3 4 5 6 7 8 9))
              true))
 
-(t/deftest test-ns
-  ;; Create a namespace called foo
-  (in-ns :foo)
-  (def bar :humbug)
-  (defn baz [x y] (+ x y))
-  ;; Back into the text namespace
-  (in-ns :pixie.tests.test-stdlib)
-  (t/assert= (set (keys (ns-map 'foo)))
-             #{'bar 'baz}))
-
-(t/deftest test-ns-aliases
-  (in-ns :ns-to-require)
-  (in-ns :my-fake-ns)
-  (require ns-to-require :as some-alias)
-  (in-ns :pixie.tests.test-stdlib)
-  (t/assert= {'some-alias (the-ns 'ns-to-require)
-              'pixie.stdlib (the-ns 'pixie.stdlib)}
-             (ns-aliases (the-ns 'my-fake-ns))))
-
 (t/deftest test-while
   (t/assert=  (while (pos? 0) true ) nil)
   (t/assert=  (while (pos? 0) false) nil)

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -485,6 +485,26 @@
                 '(0 1 2 3 4 5 6 7 8 9))
              true))
 
+(t/deftest test-ns
+  ;; Create a namespace called foo
+  (in-ns :foo)
+  (eval '(def bar :humbug))
+  (eval '(defn baz  [x y]  (+ x y)))
+  ;; Back into the text namespace
+  (in-ns :pixie.tests.test-stdlib)
+  (t/assert= (set  (keys  (ns-map 'foo)))
+             #{'bar 'baz}))
+
+(t/deftest test-ns-aliases
+  (in-ns :ns-to-require)
+  (in-ns :my-fake-ns)
+  (require ns-to-require :as some-alias)
+  (in-ns :pixie.tests.test-stdlib)
+  (t/assert= {'some-alias  (the-ns 'ns-to-require)
+              'pixie.stdlib  (the-ns 'pixie.stdlib)}
+             (ns-aliases  (the-ns 'my-fake-ns))))
+
+
 (t/deftest test-while
   (t/assert=  (while (pos? 0) true ) nil)
   (t/assert=  (while (pos? 0) false) nil)
@@ -674,6 +694,7 @@
   (t/assert-throws? RuntimeException
     "proto must be a Protocol"
     (satisfies? [IIndexed :also-not-a-proto] [1 2]))
+  (in-ns :pixie.tests.test-stdlib)
   (defprotocol IFoo (foo [this]))
   (extend-protocol IFoo
     Number


### PR DESCRIPTION
This is an attempt to address #366

This makes `in-ns` just a regular function. Things seem to mostly just work, but i had to change some of the tests slightly.  I think most of the issues were probably to with the `deftest` macro. For example the `defprotocol` inside a test broke unless i put a `(in-ns ...)` before it. Also I had to wrap some code in `eval` so it would end up in the `foo` namespace and not in the `pixie.test.test-stdlib` namespace.

Ideally we shouldn't have to make the changes I made to the tests. Any thoughts?

Cheers.