### PR TITLE
fix transducer composition problems, add tests

### DIFF
--- a/pixie/io.pxi
+++ b/pixie/io.pxi
@@ -66,14 +66,13 @@
             (str string))))))
   IReduce
   (-reduce [this f init]
-    (let [rrf (preserving-reduced f)]
-      (loop [acc init]
-        (if-let [line (-read-line this)]
-          (let [result (rrf acc line)]
-            (if (not (reduced? result))
-              (recur result)
-              @result))
-          acc)))))
+    (loop [acc init]
+      (if-let [line (-read-line this)]
+        (let [result (f acc line)]
+          (if (reduced? result)
+            @result
+            (recur result)))
+        acc))))
 
 (defn line-reader
   [input-stream]
@@ -150,14 +149,13 @@
 (deftype BufferedInputStream [upstream idx buffer]
   IReduce
   (-reduce [this f init]
-    (let [rrf (preserving-reduced f)]
-      (loop [acc init]
-        (if-let [next-byte (read-byte this)]
-          (let [step (rrf acc next-byte)]
-            (if (reduced? step)
-              @step
-              (recur step)))
-          acc))))
+    (loop [acc init]
+      (if-let [next-byte (read-byte this)]
+        (let [result (f acc next-byte)]
+          (if (reduced? result)
+            @result
+            (recur result)))
+        acc)))
   IByteInputStream
   (read-byte [this]
     (when (= idx (count buffer))


### PR DESCRIPTION
Remove `preserving-reduced` from several transducers. This was modifying
the reducing function passed to the transducer, causing reduced values
to be wrapped in `reduced` twice, so the reducing process wasn't
completely unwrapping reduced values when
finishing. Reducing functions only need to be wrapped with
`preserving-reduced` if they call `reduce` themselves. (Like `cat` and
`pixie.io.common/stream-reducer`)

For example

    (transduce (comp (drop 1) (take 2)) conj [1 2 3 4])
would not return the expected result of `[2 3]` 

Also fixes a problem with the `take` transducer consuming one more
element than needed.

Add tests for these problems.