### PR TITLE
for bindings can depend on previous ones.

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -2606,14 +2606,14 @@ Expands to calls to `extend-type`."
                        `(loop [res# []
                                ~c (seq ~coll)]
                           (if ~c
-                            (recur (into res#
-                                         ~(gen-loop (into coll-bindings
-                                                          [binding `(first ~c)])
-                                                    (nnext bindings)))
-                                   (next ~c))
+                            (let [~binding (first ~c)]
+                              (recur (into res#
+                                           ~(gen-loop (into coll-bindings
+                                                            [binding `(first ~c)])
+                                                      (nnext bindings)))
+                                     (next ~c)))
                             res#)))
-                     `(let ~coll-bindings
-                        [~@body])))]
+                     `[~@body]))]
     `(or (seq ~(gen-loop [] bindings)) '())))
 
 (defmacro doto

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -452,7 +452,11 @@
   (t/assert= (for [x [1 2 3] y [:a :b :c]] [x y])
              [[1 :a] [1 :b] [1 :c]
               [2 :a] [2 :b] [2 :c]
-              [3 :a] [3 :b] [3 :c]]))
+              [3 :a] [3 :b] [3 :c]])
+  (t/assert= (for [x [[1 2 3]]
+                   y x]
+               y)
+             [1 2 3]))
 
 (t/deftest test-doto
   (let [a (atom 0)]


### PR DESCRIPTION
This change allows `for` bindings to depend on previous ones, i.e., `(for [x [[1 2 3]] y x] y)`

I don't see any new edge cases from this.
