### PR TITLE
[wip] Added watching and compare-and-set! for atoms

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -3110,3 +3110,15 @@ ex: (vary-meta x assoc :foo 42)"
    :added "0.1"}
   [f x]
   (->Iterate f x))
+
+(defn compare-and-set! 
+  {:doc "Atomically sets the value of the atom to newval iff the current value of atom is oldval. 
+         Returns true if reset happens, else false."
+   :signatures [[atom oldval newval]]
+   :added "0.2"}
+  [atom oldval newval]
+  (if (= @atom oldval)
+    (do
+      (reset! atom newval)
+      true)
+    false)

--- a/pixie/vm/atom.py
+++ b/pixie/vm/atom.py
@@ -13,17 +13,40 @@ class Atom(object.Object):
     def meta(self):
         return self._meta
 
-    def __init__(self, boxed_value, meta=nil):
+    def with_validator(self, validator):
+        return Atom(self._boxed_value, 
+                    self._meta,
+                    self._watch_key,
+                    self._watch_fn,
+                    validator=validator)
+    
+    def with_watch(self, watch_key, watch_fn):
+        return Atom(self._boxed_value,
+                    self._meta,
+                    watch_key,
+                    watch_fn,
+                    self._validator)
+    
+    def __init__(self, boxed_value, 
+                 meta=nil,
+                 watch_key=nil, watch_fn=nil,
+                 validator=nil):
         self._boxed_value = boxed_value
         self._meta = meta
+        self._watch_key = watch_key
+        self._watch_fn = watch_fn
+        self._validator = validator
 
 
 @extend(proto._reset_BANG_, Atom)
 def _reset(self, v):
     assert isinstance(self, Atom)
+    if self._validator is not nil:
+        affirm(self._validator.invoke([v]), u"Invalid State Exception: Invalid reference state.")
+    if self._watch_fn is not nil:
+        self._watch_fn.invoke([self._watch_key, self, self._boxed_value, v])
     self._boxed_value = v
     return v
-
 
 @extend(proto._deref, Atom)
 def _deref(self):
@@ -39,6 +62,16 @@ def _meta(self):
 def _with_meta(self, meta):
     assert isinstance(self, Atom)
     return self.with_meta(meta)
+
+@extend(proto._with_watch, Atom)
+def _with_watch(self, watch_key, watch_fn):
+    assert isinstance(self, Atom)
+    return self.with_watch(watch_key, watch_fn)
+
+@extend(proto._with_validator, Atom)
+def _with_validator(self, validate_fn):
+    assert isinstance(self, Atom)
+    return self.with_validator(validate_fn)
 
 @as_var("atom")
 def atom(val=nil):

--- a/pixie/vm/atom.py
+++ b/pixie/vm/atom.py
@@ -1,5 +1,4 @@
 import pixie.vm.object as object
-from pixie.vm.object import affirm
 from pixie.vm.code import extend, as_var
 from pixie.vm.primitives import nil
 import pixie.vm.stdlib as proto
@@ -14,36 +13,23 @@ class Atom(object.Object):
     def meta(self):
         return self._meta
 
-    def with_validator(self, validator):
-        return Atom(self._boxed_value, 
-                    self._meta,
-                    self._watch_key,
-                    self._watch_fn,
-                    validator=validator)
-    
     def with_watch(self, watch_key, watch_fn):
         return Atom(self._boxed_value,
                     self._meta,
                     watch_key,
-                    watch_fn,
-                    self._validator)
+                    watch_fn)
     
     def __init__(self, boxed_value, 
                  meta=nil,
-                 watch_key=nil, watch_fn=nil,
-                 validator=nil):
+                 watch_key=nil, watch_fn=nil)
         self._boxed_value = boxed_value
         self._meta = meta
         self._watch_key = watch_key
         self._watch_fn = watch_fn
-        self._validator = validator
-
 
 @extend(proto._reset_BANG_, Atom)
 def _reset(self, v):
     assert isinstance(self, Atom)
-    if self._validator is not nil:
-        affirm(self._validator.invoke([v]), u"Invalid State Exception: Invalid reference state.")
     if self._watch_fn is not nil:
         self._watch_fn.invoke([self._watch_key, self, self._boxed_value, v])
     self._boxed_value = v
@@ -68,11 +54,6 @@ def _with_meta(self, meta):
 def _with_watch(self, watch_key, watch_fn):
     assert isinstance(self, Atom)
     return self.with_watch(watch_key, watch_fn)
-
-@extend(proto._with_validator, Atom)
-def _with_validator(self, validate_fn):
-    assert isinstance(self, Atom)
-    return self.with_validator(validate_fn)
 
 @as_var("atom")
 def atom(val=nil):

--- a/pixie/vm/atom.py
+++ b/pixie/vm/atom.py
@@ -1,4 +1,5 @@
 import pixie.vm.object as object
+from pixie.vm.object import affirm
 from pixie.vm.code import extend, as_var
 from pixie.vm.primitives import nil
 import pixie.vm.stdlib as proto

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -63,6 +63,9 @@ defprotocol("pixie.stdlib", "IFinalize", ["-finalize!"])
 
 defprotocol("pixie.stdlib", "IMessageObject", ["-call-method", "-get-attr"])
 
+defprotocol("pixie.stdlib", "IWatch", ["-with-watch"])
+defprotocol("pixie.stdlib", "IValidate", ["-with-validator"])
+
 def maybe_mark_finalizer(self, tp):
     if self is _finalize_BANG_:
         print "MARKING ", tp

--- a/pixie/vm/stdlib.py
+++ b/pixie/vm/stdlib.py
@@ -281,6 +281,10 @@ def __meta(a):
 def __with_meta(a, b):
     return rt._with_meta(a, b)
 
+@as_var("with-watch")
+def __with_watch(a, b, c):
+    return rt._with_watch(a, b, c)
+
 @returns(bool)
 @as_var("has-meta?")
 def __has_meta(a):


### PR DESCRIPTION
Added watches and `compare-and-set!` as requested in issue #424 
Includes a protocol `IWatch` with method `-with-watch`.

I'm still writing the tests, so the changes are still provisional.