### PR TITLE
Add test for the letfn macro

### DIFF
--- a/pixie/stdlib.pxi
+++ b/pixie/stdlib.pxi
@@ -482,6 +482,19 @@
   (let [nm (with-meta nm (assoc (meta nm) :private true))]
     (cons `defn (cons nm rest))))
 
+(defmacro letfn
+  "fnspec ==> (fname [params*] exprs) or (fname ([params*] exprs)+)
+
+  Takes a vector of function specs and a body, and generates a set of
+  bindings of functions to their names. All of the names are available
+  in all of the definitions of the functions, as well as the body."
+  {:added "0.2" 
+   :forms '[(letfn [fnspecs*] exprs*)]}
+  [fnspecs & body]
+  `(letfn* ~(vec (interleave (map first fnspecs)
+                             (map #(cons `fn %) fnspecs)))
+           ~@body))
+               
 (defn not
   {:doc "Inverts the input, if a truthy value is supplied, returns false, otherwise
 returns true."

--- a/tests/pixie/tests/test-stdlib.pxi
+++ b/tests/pixie/tests/test-stdlib.pxi
@@ -829,3 +829,16 @@
                                                                                    :b 2
                                                                                    "c" 3
                                                                                    "d" 4}))))))
+
+(t/deftest test-letfn
+  (letfn [(hello [] "Hello")
+          (adder [x y] (+ x y))]
+    (t/assert= "Hello" (hello))
+    (dotimes [i 10]
+      (dotimes [j 20]
+        (t/assert= (+ i j) (adder i j)))))
+  (letfn [(f [x n] (vec (repeat n x)))]
+    (t/assert= (f :x 3) [:x :x :x])
+    (t/assert= (f 0 20) [0 0 0 0 0
+                         0 0 0 0 0
+                         0 0 0 0 0])))


### PR DESCRIPTION
Sorry, I realized I never actually added the tests for the `letfn` macro, and for some reason I can't figure out how to add the test to the test file in #528.